### PR TITLE
Add the ksql-examples docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 dockerfile {
     upstreamProjects = ['confluentinc/common-docker', 'confluentinc/ksql']
-    dockerRepos = ['confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli']
+    dockerRepos = ['confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli', 'confluentinc/ksql-examples']
     dockerPullDeps = ['confluentinc/cp-base-new']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
     mvnPhase = 'package'

--- a/cp-ksql-examples/Dockerfile
+++ b/cp-ksql-examples/Dockerfile
@@ -5,8 +5,9 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
+ARG KSQL_EXAMPLES_ARTIFACT_ID
 
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
+ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${KSQL_EXAMPLES_ARTIFACT_ID}/
+ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${KSQL_EXAMPLES_ARTIFACT_ID}/
 ADD target/dependency/ksql-console-scripts-${PROJECT_VERSION}/* /usr/bin/
 ADD target/dependency/ksql-etc-${PROJECT_VERSION}/* /etc/ksql/

--- a/cp-ksql-examples/pom.xml
+++ b/cp-ksql-examples/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>ksql-examples</artifactId>
             <version>${project.version}</version>
         </dependency>
- 
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksql-console-scripts</artifactId>
@@ -101,6 +101,25 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <includeArtifactIds>ksql-console-scripts,ksql-etc</includeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <buildArgs>
+                                <KSQL_EXAMPLES_ARTIFACT_ID>ksql-examples</KSQL_EXAMPLES_ARTIFACT_ID>
+                            </buildArgs>
+                            <repository>${docker.registry}confluentinc/ksql-examples</repository>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <modules>
         <module>cp-ksql-server</module>
         <module>cp-ksql-cli</module>
+        <module>cp-ksql-examples</module>
     </modules>
     
     <properties>


### PR DESCRIPTION
This patch enables building the ksql-examples docker image. This is a
bit tricky because we want to build an image named ksql-examples but
have an artifact id of cp-ksql-examples, to avoid colliding with the
ksql-examples artifact from the ksql repo. So we have to update the
maven dockerfile plug-in and Dockerfile accordingly.