### PR TITLE
(maybe) fix typo in tox.inl

### DIFF
--- a/cp-ksql-server/tox.ini
+++ b/cp-ksql-server/tox.ini
@@ -7,7 +7,7 @@ toxworkdir = /var/tmp
 # have a single env (platform) to work with, which makes debugging easier (like which env?).
 # Not as clean but easier to work with for dev, which is better.
 deps =
-    -rrequirements.txt
+    -requirements.txt
     flake8
     pytest
     pytest-xdist


### PR DESCRIPTION
I'm pretty sure this is what is causing the Jenkins failures, but I'm not sure how to trigger it locally so I'm creating a PR to auto-trigger a Jenkins build.