### PR TITLE
update dependency to fix tests

### DIFF
--- a/cp-ksql-server/requirements.txt
+++ b/cp-ksql-server/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.25
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.30

--- a/cp-ksql-server/tox.ini
+++ b/cp-ksql-server/tox.ini
@@ -12,7 +12,6 @@ deps =
     pytest
     pytest-xdist
     pytest-cov
-    sphinx!=1.2b2
 install_command = pip install -U {packages}
 recreate = True
 skipsdist = True
@@ -21,7 +20,7 @@ setenv =
     PIP_PROCESS_DEPENDENCY_LINKS=1
     PIP_DEFAULT_TIMEOUT=60
     ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
-basepython = python
+basepython = python3
 envdir = {toxworkdir}/confluent
 
 [testenv:test]


### PR DESCRIPTION
This fixes the broken dependencies
```
ERROR: invocation failed (exit code 1), logfile: /var/tmp/confluent/log/test-1.log
================================== log start ===================================
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Looking in indexes: https://****:****@nexus.confluent.io/repository/pypi/simple
Collecting git+https://github.com/confluentinc/confluent-docker-utils@v0.0.25 (from -r requirements.txt (line 1))
  Cloning https://github.com/confluentinc/confluent-docker-utils (to revision v0.0.25) to /tmp/pip-req-build-5dvHU1
Collecting flake8
  Downloading https://nexus.confluent.io/repository/pypi/packages/e9/76/b915bd28976068a9843bf836b789794aa4a8eb13338b23581005cd9177c0/flake8-3.7.7-py2.py3-none-any.whl (68kB)
Collecting pytest
  Downloading https://nexus.confluent.io/repository/pypi/packages/7e/16/83b2a35c427b838df9836c9e7e4ae6dfbcbdea643db44652f693b1c57d70/pytest-4.4.0-py2.py3-none-any.whl (223kB)
Collecting pytest-xdist
  Downloading https://nexus.confluent.io/repository/pypi/packages/9f/ea/227e5ec64bd5deb31011fb2a2557d62d5c06c4793a8bfc4f47d398714e1c/pytest_xdist-1.28.0-py2.py3-none-any.whl
Collecting pytest-cov
  Downloading https://nexus.confluent.io/repository/pypi/packages/7d/b5/92f32674ab954f80499ac73347bfeb815545ea295439c12b0ef3ac8f0975/pytest_cov-2.6.1-py2.py3-none-any.whl
Collecting sphinx!=1.2b2
  Downloading https://nexus.confluent.io/repository/pypi/packages/9a/b0/a8cf1d35237aebefd63f05543ed49ea24d302239828ca89409b0c1a35b27/Sphinx-2.0.1-py2.py3-none-any.whl (3.2MB)
Sphinx requires Python '>=3.5' but the running Python is 2.7.9

=================================== log end ====================================
```