### PR TITLE
Added Testing tool to the CLI image

### DIFF
--- a/cp-ksql-cli/pom.xml
+++ b/cp-ksql-cli/pom.xml
@@ -35,16 +35,67 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksql-cli</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ksql-functional-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+                 <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>5.4.0-ccs-SNAPSHOT</version>
+            <classifier>test</classifier>
+            <scope>compile</scope>
+        </dependency>
+
+         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams-test-utils</artifactId>
+            <version>5.4.0-ccs-SNAPSHOT</version>
+        </dependency>
+
+         <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-metastore</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+         <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-engine</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+         <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+        </dependency>
+
+
+         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>compile</scope>
+        </dependency>
+
+         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR adds the testing tool to the CLI docker image. This will allow the users to bring up the CLI containers and run the KSQL functional tests in the container.
To simplify running KSQL functional tests, users can start the CLI container along with bindmounting a local folder in the machine that runs the container. This way they can keep editing the test files in the local machine with the desired editor and run the tests in the container.

As an example, consider we have the test files in the home folder of the local machine and we want to bimount this folder to the `home` folder in the container. We can start the CLI container with the following command:

```bash
docker run -it -v ~/:/home 213e1be99dd3
```
213e1be99dd3 is the container ID in the above command. 
This will start the CLI container and bimount the local home directory to the container directory.
Now users can run the test either from their machine via `docker exec` command or first connect to the container and then run the tests.
If running using `docker exec` the following command can be used:

```bash
docker exec  ec0059b5cd3a /usr/bin/ksql-test-runner -i /home/md_i.json -o /home/md_o.json -s /home/md_s.sql
```

where ec0059b5cd3a is the container id.

If we want to connect to the container and run the tests from the container, the following command in the container can be used:

```bash
/usr/bin/ksql-test-runner -i /home/md_i.json -o /home/md_o.json -s /home/md_s.sql
```
If we need to change test files, we can update them in the local machine and run the tests from the container again. The container will pick up the changes in the test files.

