### PR TITLE
Add KSQL security plugins for RBAC

### DIFF
--- a/cp-ksql-server/pom.xml
+++ b/cp-ksql-server/pom.xml
@@ -83,6 +83,12 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-ksql-security-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This PR adds the KSQL security plugins to the server docker images so we can test RBAC in docker