### PR TITLE
Add KSQL Server Docker healthcheck

### DIFF
--- a/cp-ksql-server/Dockerfile
+++ b/cp-ksql-server/Dockerfile
@@ -35,8 +35,8 @@ CMD ["/etc/confluent/docker/run"]
 
 # Polling period  : 5 seconds
 # Timeout period  :10 seconds (if the polling does not return within this time, treat as a failed poll)
-# Start-up period : 2 minutes (during which failures are not counted as failures)
-# Retry period    : 8 minutes (after which container is deemed unhealthy)
+# Start-up period :10 minutes (during which failures are not counted as failures)
+# Retry period    :30 seconds (after which container is deemed unhealthy)
 # All settings can be overriden at run-time in Docker/Docker Compose. 
-HEALTHCHECK --start-period=120s --interval=5s --timeout=10s --retries=96 \
+HEALTHCHECK --start-period=600s --interval=5s --timeout=10s --retries=6 \
 	CMD /etc/confluent/docker/healthcheck.sh

--- a/cp-ksql-server/include/etc/confluent/docker/healthcheck.sh
+++ b/cp-ksql-server/include/etc/confluent/docker/healthcheck.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-curl_status=$(curl -s -o /dev/null -w %{http_code} $KSQL_LISTENERS/info) 
+curl_status=$(curl -X POST -s -o /dev/null -w %{http_code} $KSQL_LISTENERS/ksql -H 'content-type: application/vnd.ksql.v1+json; charset=utf-8' -d '{"ksql":"SHOW TOPICS;"}') 
 if [ $curl_status -eq 200 ]; then
   echo "Woohoo! KSQL is up!"
   exit 0
 else
-  echo -e $(date) " KSQL server listener HTTP state: " $curl_status " (waiting for 200)" 
+  echo -e $(date) " KSQL server query response code: " $curl_status " (waiting for 200)" 
   exit 1
 fi 


### PR DESCRIPTION
Testing done : added healthcheck to a local build of the image, tested it successfully: 

Docker shows the container as `healthy`: 

```
$ docker ps
CONTAINER ID        IMAGE                                                 COMMAND                   CREATED             STATUS                   PORTS                              NAMES
8d6064b719f5        confluentinc/cp-enterprise-control-center:5.3.0       "bash -c 'echo \"Wait…"   5 minutes ago       Up 5 minutes             0.0.0.0:9021->9021/tcp             control-center
f433a6ef6f96        confluentinc/cp-ksql-cli:5.3.0                        "/bin/sh"                 5 minutes ago       Up 5 minutes                                                ksql-cli
2934a6fd17d5        confluentinc/cp-kafka-connect:5.3.0                   "bash -c 'echo \"Inst…"   5 minutes ago       Up 5 minutes             0.0.0.0:8083->8083/tcp, 9092/tcp   kafka-connect-01
a5c50f2590ea        confluentinc/cp-schema-registry:5.3.0                 "/etc/confluent/dock…"    5 minutes ago       Up 5 minutes             0.0.0.0:8081->8081/tcp             schema-registry
a6e6efadde0d        ksql-server-healthcheck                               "/etc/confluent/dock…"    5 minutes ago       Up 4 minutes (healthy)   0.0.0.0:8088->8088/tcp             ksql-server
[…]
```

```
$ docker inspect ksql-server|jq '.[].State.Health'
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2019-08-06T21:24:45.2994123Z",
      "End": "2019-08-06T21:24:45.5405994Z",
      "ExitCode": 1,
      "Output": "Tue Aug 6 21:24:45 UTC 2019 \tKSQL HTTP state:  000  (waiting for 200)\n"
    },
    {
      "Start": "2019-08-06T21:24:50.5501618Z",
      "End": "2019-08-06T21:24:51.2078062Z",
      "ExitCode": 1,
      "Output": "Tue Aug 6 21:24:51 UTC 2019 \tKSQL HTTP state:  503  (waiting for 200)\n"
    },
    {
      "Start": "2019-08-06T21:24:56.2132311Z",
      "End": "2019-08-06T21:24:56.4744598Z",
      "ExitCode": 0,
      "Output": "Woohoo! KSQL is up!\n"
    },
    {
      "Start": "2019-08-06T21:25:01.4814845Z",
      "End": "2019-08-06T21:25:01.6563264Z",
      "ExitCode": 0,
      "Output": "Woohoo! KSQL is up!\n"
    },
    {
      "Start": "2019-08-06T21:25:06.6621997Z",
      "End": "2019-08-06T21:25:06.8860803Z",
      "ExitCode": 0,
      "Output": "Woohoo! KSQL is up!\n"
    }
  ]
}
```