### PR TITLE
Minor: fix docker test tag

### DIFF
--- a/cp-ksql-server/pom.xml
+++ b/cp-ksql-server/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
+        <docker.test-tag>5.3.x-latest</docker.test-tag>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Builds are currently failing with 
```
docker.errors.NotFound: 404 Client Error: Not Found ("manifest for 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-zookeeper:master-latest not found")
```
since the [cp-ksql-server integration test](https://github.com/confluentinc/ksql-images/blob/216bc78c46c33aa3d387920b46e852c68c0178aa/cp-ksql-server/test/fixtures/basic-cluster.yml) is trying to pull an image that doesn't exist. This PR updates `docker.test-tag` from the default of `master-latest` to `5.3.x-latest` so the test passes again.

Relevant Slack threads:
https://confluent.slack.com/archives/C8486MR1C/p1566631681070500?thread_ts=1566606620.068200&cid=C8486MR1C
https://confluent.slack.com/archives/C09EP1SS3/p1566631359438800