### PR TITLE
fix python2 compatblity

### DIFF
--- a/cp-ksql-cli/include/etc/confluent/docker/log4j.properties.template
+++ b/cp-ksql-cli/include/etc/confluent/docker/log4j.properties.template
@@ -10,7 +10,7 @@ log4j.appender.default.file.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 {% if env['KSQL_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['KSQL_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}

--- a/cp-ksql-server/include/etc/confluent/docker/ksql-server.properties.template
+++ b/cp-ksql-server/include/etc/confluent/docker/ksql-server.properties.template
@@ -1,4 +1,4 @@
 {% set kr_props = env_to_props('KSQL_', '') -%}
-{% for name, value in kr_props.iteritems() -%}
+{% for name, value in kr_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/cp-ksql-server/include/etc/confluent/docker/log4j.properties.template
+++ b/cp-ksql-server/include/etc/confluent/docker/log4j.properties.template
@@ -14,7 +14,7 @@ log4j.logger.processing=ERROR, kafka_appender
 
 {% if env['KSQL_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['KSQL_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
The new cp-docker base image now use python3, there is some incompatible in the template and cause the build failure.