### PR TITLE
Use docker swarm nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ dockerfile {
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
     mvnPhase = 'package integration-test'
     mvnSkipDeploy = true
-    nodeLabel = 'docker-oraclejdk8-compose'
+    nodeLabel = 'docker-oraclejdk8-compose-swarm'
     dockerPush = true
     slackChannel = '#ksql-alerts'
 }


### PR DESCRIPTION
We should be using the new docker swarm nodes because the pool is much bigger.