### PR TITLE
ST-3800: Remove upstream projects

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    upstreamProjects = ['confluentinc/common-docker', 'confluentinc/ksql']
     dockerRepos = ['confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli', 'confluentinc/ksql-examples']
     dockerPullDeps = ['confluentinc/cp-base-new']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'


### PR DESCRIPTION
We no longer need to declare up stream jobs for this repo because it will get started after those jobs run anyways by the overlay job. Also, every time these jobs trigger a build of this repo it fails on beta and rc branches because the required artifacts are not ready yet. If ksql finishes and triggers this build the common-docker build may not have run yet so the base image is not available and this fails. If common docker triggers this build the required parameters are not passed in so it fails.