### PR TITLE
ST-2560: Adding support for building debian and rhel images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    dockerRepos = ['confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli', 'confluentinc/ksql-examples']
+    dockerRepos = ['confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli',
+      'confluentinc/ksql-examples']
     dockerPullDeps = ['confluentinc/cp-base-new']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
     mvnPhase = 'package integration-test'
@@ -10,4 +11,6 @@ dockerfile {
     dockerPush = true
     slackChannel = '#ksql-alerts'
     cron = ''
+    cpImages = true
+    osTypes = ['deb9', 'rhel8']
 }

--- a/cp-ksql-cli/include/etc/confluent/docker/log4j.properties.template
+++ b/cp-ksql-cli/include/etc/confluent/docker/log4j.properties.template
@@ -10,7 +10,7 @@ log4j.appender.default.file.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 {% if env['KSQL_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['KSQL_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}

--- a/cp-ksql-server/include/etc/confluent/docker/ksql-server.properties.template
+++ b/cp-ksql-server/include/etc/confluent/docker/ksql-server.properties.template
@@ -1,4 +1,4 @@
 {% set kr_props = env_to_props('KSQL_', '') -%}
-{% for name, value in kr_props.iteritems() -%}
+{% for name, value in kr_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}

--- a/cp-ksql-server/include/etc/confluent/docker/log4j.properties.template
+++ b/cp-ksql-server/include/etc/confluent/docker/log4j.properties.template
@@ -14,7 +14,7 @@ log4j.logger.processing=ERROR, kafka_appender
 
 {% if env['KSQL_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['KSQL_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}

--- a/pom.xml
+++ b/pom.xml
@@ -25,5 +25,9 @@
     
     <properties>
         <component.name>ksql</component.name>
+        <docker.os_type>deb9</docker.os_type>
+        <!-- Need to explicitly set this otherwise it will be overridden from common-docker pom. -->
+        <docker.file>Dockerfile</docker.file>
+        <docker.tag>${project.version}-${docker.os_type}</docker.tag>
     </properties>
 </project>


### PR DESCRIPTION
Since this image is built from artifacts and not packages we don't need to create separate docker files for each os type we want to build, which is the pattern we use with the other images that are built from packages. This change will build the same docker file twice but each time using a different docker upstream tag so that it uses a different base image each time.

I have tested the debian images locally and it worked with cp-demo. Testing of the rhel images with cp-demo is still on going.