### PR TITLE
Minor: add confluent-hub to ksqldb server and cli images

### DIFF
--- a/cp-ksql-cli/Dockerfile.deb9
+++ b/cp-ksql-cli/Dockerfile.deb9
@@ -24,6 +24,11 @@ COPY include/etc/confluent/docker /etc/confluent/docker
 
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
+RUN echo "===> Installing confluent-hub..." \
+  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+  && tar xf confluent-hub-client-latest.tar.gz \
+  && rm confluent-hub-client-latest.tar.gz
+
 RUN bash /etc/confluent/docker/configure
 ENV KSQL_LOG4J_OPTS=-Dlog4j.configuration=file:/etc/${COMPONENT}/log4j.properties
 

--- a/cp-ksql-cli/Dockerfile.ubi8
+++ b/cp-ksql-cli/Dockerfile.ubi8
@@ -33,6 +33,11 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT} /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /var/log/${COMPONENT} /usr/logs
 
+RUN echo "===> Installing confluent-hub..." \
+  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+  && tar xf confluent-hub-client-latest.tar.gz \
+  && rm confluent-hub-client-latest.tar.gz
+
 USER appuser
 
 RUN bash /etc/confluent/docker/configure

--- a/cp-ksql-server/Dockerfile.deb9
+++ b/cp-ksql-server/Dockerfile.deb9
@@ -26,6 +26,11 @@ COPY include/etc/confluent/docker /etc/confluent/docker
 
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
+RUN echo "===> Installing confluent-hub..." \
+  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+  && tar xf confluent-hub-client-latest.tar.gz \
+  && rm confluent-hub-client-latest.tar.gz
+
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 RUN chmod +x /etc/confluent/docker/launch

--- a/cp-ksql-server/Dockerfile.ubi8
+++ b/cp-ksql-server/Dockerfile.ubi8
@@ -35,6 +35,11 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs
 
+RUN echo "===> Installing confluent-hub..." \
+  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+  && tar xf confluent-hub-client-latest.tar.gz \
+  && rm confluent-hub-client-latest.tar.gz
+
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 RUN chmod +x /etc/confluent/docker/launch


### PR DESCRIPTION
^ for consistency with the community ksqlDB images (https://github.com/confluentinc/ksql/pull/4729).

Slack conversation: https://confluent.slack.com/archives/C8486MR1C/p1584107074300800?thread_ts=1584048653.296300&cid=C8486MR1C

Note that this change is targeted at master and not 5.5, so the change will only be available starting in 6.0 (or whatever the next release after 5.5 is).