### PR TITLE
properly set KSQL_LOG4J_OPTS for launching server

### DIFF
--- a/cp-ksqldb-server/include/etc/confluent/docker/configure
+++ b/cp-ksqldb-server/include/etc/confluent/docker/configure
@@ -30,6 +30,3 @@ fi
 
 dub template "/etc/confluent/docker/ksql-server.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
 dub template "/etc/confluent/docker/log4j.properties.template" "/etc/${COMPONENT}/log4j.properties"
-
-# Ensure that KSQL picks up the correct log4j properties file
-export KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/${COMPONENT}/log4j.properties"

--- a/cp-ksqldb-server/include/etc/confluent/docker/launch
+++ b/cp-ksqldb-server/include/etc/confluent/docker/launch
@@ -19,6 +19,11 @@ if [ -z "$KSQL_JMX_OPTS" ]; then
   KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
 fi
 
+# Ensure that KSQL picks up the correct log4j properties file
+if [ -z "$KSQL_LOG4J_OPTS" ]; then
+  export KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/${COMPONENT}/log4j.properties"
+fi
+
 # The JMX client needs to be able to connect to java.rmi.server.hostname.
 # The default for bridged network is the bridged IP so you will only be able to connect from another docker container.
 # For host network, this is the IP that the hostname on the host resolves to.

--- a/cp-ksqldb-server/include/etc/confluent/docker/run
+++ b/cp-ksqldb-server/include/etc/confluent/docker/run
@@ -23,7 +23,7 @@ echo "===> User"
 id
 
 echo "===> Configuring ..."
-. /etc/confluent/docker/configure
+/etc/confluent/docker/configure
 
 echo "===> Running preflight checks ... "
 /etc/confluent/docker/ensure

--- a/cp-ksqldb-server/include/etc/confluent/docker/run
+++ b/cp-ksqldb-server/include/etc/confluent/docker/run
@@ -23,7 +23,7 @@ echo "===> User"
 id
 
 echo "===> Configuring ..."
-/etc/confluent/docker/configure
+. /etc/confluent/docker/configure
 
 echo "===> Running preflight checks ... "
 /etc/confluent/docker/ensure


### PR DESCRIPTION
`export KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/${COMPONENT}/log4j.properties"` is being called in `/etc/confluent/docker/configure` but it's being executed in a subshell of the run script, so it's not present when actually starting up the server in `/etc/confluent/docker/launch`

Moved setting the environment variable to the launch script

Verified this works with the clickstreams demo (embedded connect logs show up in docker-compose logs). Removed these two environment variables from the docker-compose and it still showed.
```
      KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql-server/log4j.properties"
      KSQL_LOG4J_ROOT_LOGLEVEL: INFO
```

Used this image: confluent-docker.jfrog.io/confluentinc/cp-ksqldb-server:steven-ksqldb-server-log4j-fix

https://askubuntu.com/questions/53177/bash-script-to-set-environment-variables-not-working
