### PR TITLE
ST-3599: Remove show_env function because it exposes secrets

### DIFF
--- a/cp-ksql-cli/include/etc/confluent/docker/configure
+++ b/cp-ksql-cli/include/etc/confluent/docker/configure
@@ -16,9 +16,6 @@
 
 . /etc/confluent/docker/bash-config
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 

--- a/cp-ksql-server/include/etc/confluent/docker/run
+++ b/cp-ksql-server/include/etc/confluent/docker/run
@@ -16,9 +16,6 @@
 
 . /etc/confluent/docker/bash-config
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 


### PR DESCRIPTION
We don't want to print the environment variables in the logs during startup because they contain sensitive data.