### PR TITLE
SEC-1034: remove hub-client from ksql images

### DIFF
--- a/cp-ksqldb-cli/Dockerfile.deb9
+++ b/cp-ksqldb-cli/Dockerfile.deb9
@@ -24,11 +24,6 @@ COPY include/etc/confluent/docker /etc/confluent/docker
 
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT}
 
-RUN echo "===> Installing confluent-hub..." \
-  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
-  && tar xf confluent-hub-client-latest.tar.gz \
-  && rm confluent-hub-client-latest.tar.gz
-
 RUN bash /etc/confluent/docker/configure
 ENV KSQL_LOG4J_OPTS=-Dlog4j.configuration=file:/etc/${COMPONENT}/log4j.properties
 

--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -33,11 +33,6 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT} /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /var/log/${COMPONENT} /usr/logs
 
-RUN echo "===> Installing confluent-hub..." \
-  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
-  && tar xf confluent-hub-client-latest.tar.gz \
-  && rm confluent-hub-client-latest.tar.gz
-
 USER appuser
 
 RUN bash /etc/confluent/docker/configure

--- a/cp-ksqldb-server/Dockerfile.deb9
+++ b/cp-ksqldb-server/Dockerfile.deb9
@@ -27,11 +27,6 @@ COPY include/etc/confluent/docker/* /etc/confluent/docker/
 
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets
 
-RUN echo "===> Installing confluent-hub..." \
-  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
-  && tar xf confluent-hub-client-latest.tar.gz \
-  && rm confluent-hub-client-latest.tar.gz
-
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 RUN chmod +x /etc/confluent/docker/launch

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -36,11 +36,6 @@ COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docke
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs
 
-RUN echo "===> Installing confluent-hub..." \
-  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
-  && tar xf confluent-hub-client-latest.tar.gz \
-  && rm confluent-hub-client-latest.tar.gz
-
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 RUN chmod +x /etc/confluent/docker/launch


### PR DESCRIPTION
- Product decision to no longer bundle confluent-hub in images
- The way it was written meant that version X of ksql images would always include version X-1 of confluent hub

Context: https://confluent.slack.com/archives/C8486MR1C/p1594756787467400