### PR TITLE
[KSQL-5184] Revert "SEC-1034: remove hub-client from ksql images (#52)"

### DIFF
--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -33,6 +33,11 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT} /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /var/log/${COMPONENT} /usr/logs
 
+RUN echo "===> Installing confluent-hub..." \
+  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+  && tar xf confluent-hub-client-latest.tar.gz \
+  && rm confluent-hub-client-latest.tar.gz
+
 USER appuser
 
 RUN bash /etc/confluent/docker/configure

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -36,6 +36,11 @@ COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docke
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs
 
+RUN echo "===> Installing confluent-hub..." \
+  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
+  && tar xf confluent-hub-client-latest.tar.gz \
+  && rm confluent-hub-client-latest.tar.gz
+
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure
 RUN chmod +x /etc/confluent/docker/launch


### PR DESCRIPTION
This reverts commit 783ac1b8c0cc0b69b83215dcc9fe4e3239adeb41.

A more thorugh workaround or decision needs to be made.
In the meantime, reverting the commit so that other internal
demo related activites can continue as usual.