### PR TITLE
Install security plugins and hub client from packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ dockerfile {
     dockerPush = true
     slackChannel = '#ksql-alerts'
     cron = ''
+    usePackages = true
     cpImages = true
     osTypes = ['ubi8']
 }

--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -37,12 +37,11 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT} /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /var/log/${COMPONENT} /usr/logs
 
-RUN yum -q -y update \
-    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+RUN echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\
@@ -59,7 +58,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /usr/share/confluent-hub-components \
-    && chown appuser:appuser -R /usr/share/confluent-hub-components \
+    && chown appuser:appuser -R /usr/share/confluent-hub-components
 
 USER appuser
 

--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -21,6 +21,10 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker=true
 
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
 USER root
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
@@ -33,10 +37,29 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /var/log/${COMPONENT} /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /var/log/${COMPONENT} /usr/logs
 
-RUN echo "===> Installing confluent-hub..." \
-  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
-  && tar xf confluent-hub-client-latest.tar.gz \
-  && rm confluent-hub-client-latest.tar.gz
+RUN yum -q -y update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && echo "===> Installing Confluent Hub client ..." \
+    && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    && mkdir -p /usr/share/confluent-hub-components \
+    && chown appuser:appuser -R /usr/share/confluent-hub-components \
 
 USER appuser
 

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -40,12 +40,11 @@ COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docke
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs
 
-RUN yum -q -y update \
-    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+RUN echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/\$releasever \n\
 gpgcheck=1 \n\
 gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
 enabled=1 \n\

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -23,6 +23,10 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker=true
 
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
 USER root
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
@@ -36,10 +40,33 @@ COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docke
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
   && chown appuser:appuser -R /etc/${COMPONENT} /usr/logs
 
-RUN echo "===> Installing confluent-hub..." \
-  && wget http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz \
-  && tar xf confluent-hub-client-latest.tar.gz \
-  && rm confluent-hub-client-latest.tar.gz
+RUN yum -q -y update \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
+    && echo "===> Installing Confluent security plugins ..." \
+    && yum install -y confluent-security-${CONFLUENT_VERSION} \
+    && echo "===> Installing Confluent Hub client ..." \
+    && yum install -y confluent-hub-client-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    && mkdir -p /usr/share/confluent-hub-components \
+    && chown appuser:appuser -R /usr/share/confluent-hub-components
+
+ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
 
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -64,9 +64,9 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /usr/share/confluent-hub-components \
-    && chown appuser:appuser -R /usr/share/confluent-hub-components
-
-ENV CONNECT_PLUGIN_PATH=/usr/share/java/,/usr/share/confluent-hub-components/
+    && chown appuser:appuser -R /usr/share/confluent-hub-components \ 
+    && mkdir -p /var/lib/kafka-streams \
+    && chown appuser:appuser -R /var/lib/kafka-streams
 
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure

--- a/cp-ksqldb-server/pom.xml
+++ b/cp-ksqldb-server/pom.xml
@@ -90,12 +90,6 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-ksql-security-plugin</artifactId>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
One approach to fixing a couple of issues with ksqlDB images in 6.0 . 

Known issues:
    - We need the 6.0 version of the confluent hub client as the previous version has a CVE (the image currently pulls only publicly available images)
    - Permissions / File locations for using the confluent hub client for connect need to be modified to work with UBI8
    - Currently connecting to MDS for ksqlDB via https is broken in docker due to kafka-clients-CCS and kafka-clients-CE ending up in the same directory (and it looks like CCS gets picked up via classpath)

See: https://confluentinc.atlassian.net/browse/KSQL-5246 and https://confluentinc.atlassian.net/browse/ST-4097

This approach:
   - installs both confluent-security and confluent-hub from rpm packaging
   - creates required directories and sets permissions for appuser

Testing thus far:
    - Validated with cp-demo and connecting to MDS via https
    - Validated with clickstream example installing connectors (requires explicitly specifying --component-dir)
    - Validated with music demo
    - Validated with cp-quickstart