### PR TITLE
ST-3461: Nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,5 +13,6 @@ dockerfile {
     usePackages = true
     cpImages = true
     osTypes = ['ubi8']
+    nanoVersion = true
 }
 

--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -29,8 +29,8 @@ USER root
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-${PROJECT_VERSION}/* /usr/bin/
-ADD --chown=appuser:appuser target/dependency/ksqldb-etc-${PROJECT_VERSION}/* /etc/ksqldb/
+ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+ADD --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 

--- a/cp-ksqldb-cli/pom.xml
+++ b/cp-ksqldb-cli/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -32,7 +32,8 @@
 
     <properties>
         <docker.skip-build>false</docker.skip-build>
-        <kafka.version>6.1.0-ccs-SNAPSHOT</kafka.version>
+        <io.confluent.ksql.version>${confluent.version.range}</io.confluent.ksql.version>
+        <io.confluent.rest-utils.version>${confluent.version.range}</io.confluent.rest-utils.version>
     </properties>
 
     <dependencies>
@@ -40,21 +41,21 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.rest-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-cli</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-functional-tests</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
         </dependency>
 
-                 <dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
@@ -71,21 +72,21 @@
          <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksqldb-metastore</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <type>test-jar</type>
         </dependency>
 
          <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksqldb-engine</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <type>test-jar</type>
         </dependency>
 
          <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksqldb-common</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <type>test-jar</type>
         </dependency>
 
@@ -104,16 +105,16 @@
             <scope>compile</scope>
         </dependency>
 
-	<dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-functional-tests</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
         </dependency>
 
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>ksqldb-functional-tests</artifactId>
-          <version>${project.version}</version>
+          <version>${io.confluent.ksql.version}</version>
         </dependency>
 
         <dependency>
@@ -133,21 +134,21 @@
         <dependency>
           <groupId>io.confluent.ksql</groupId>
           <artifactId>ksqldb-metastore</artifactId>
-          <version>${project.version}</version>
+          <version>${io.confluent.ksql.version}</version>
           <type>test-jar</type>
         </dependency>
 
         <dependency>
           <groupId>io.confluent.ksql</groupId>
           <artifactId>ksqldb-engine</artifactId>
-          <version>${project.version}</version>
+          <version>${io.confluent.ksql.version}</version>
           <type>test-jar</type>
         </dependency>
 
         <dependency>
           <groupId>io.confluent.ksql</groupId>
           <artifactId>ksqldb-common</artifactId>
-          <version>${project.version}</version>
+          <version>${io.confluent.ksql.version}</version>
           <type>test-jar</type>
         </dependency>
 
@@ -168,7 +169,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-console-scripts</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
@@ -177,7 +178,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-etc</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
@@ -224,5 +225,5 @@
                 </executions>
             </plugin>
         </plugins>
-</build>
+    </build>
 </project>

--- a/cp-ksqldb-examples/Dockerfile.ubi8
+++ b/cp-ksqldb-examples/Dockerfile.ubi8
@@ -19,7 +19,7 @@ USER root
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${KSQL_EXAMPLES_ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${KSQL_EXAMPLES_ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-${PROJECT_VERSION}/* /usr/bin/
-ADD --chown=appuser:appuser target/dependency/ksqldb-etc-${PROJECT_VERSION}/* /etc/ksqldb/
+ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+ADD --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
 
 USER appuser

--- a/cp-ksqldb-examples/pom.xml
+++ b/cp-ksqldb-examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -32,6 +32,8 @@
 
     <properties>
         <docker.skip-build>false</docker.skip-build>
+        <io.confluent.blueway.version>${confluent.version.range}</io.confluent.blueway.version>
+        <io.confluent.ksql.version>${confluent.version.range}</io.confluent.ksql.version>
     </properties>
 
     <dependencies>
@@ -44,13 +46,13 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-examples</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-console-scripts</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
@@ -59,7 +61,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-etc</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
@@ -68,7 +70,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>monitoring-interceptors</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.blueway.version}</version>
         </dependency>
     </dependencies>
 

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -31,10 +31,10 @@ USER root
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-${PROJECT_VERSION}/* /usr/bin/
-ADD --chown=appuser:appuser target/dependency/ksqldb-etc-${PROJECT_VERSION}/* /etc/ksqldb/
+ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+ADD --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
 
-COPY --chown=appuser:appuser target/dependency/ksqldb-etc-${PROJECT_VERSION}/* /etc/confluent/docker/
+COPY --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/confluent/docker/
 COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docker/
 
 RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \

--- a/cp-ksqldb-server/pom.xml
+++ b/cp-ksqldb-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -34,6 +34,9 @@
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
         <docker.test-tag>5.3.x-latest</docker.test-tag>
+        <io.confluent.blueway.version>${confluent.version.range}</io.confluent.blueway.version>
+        <io.confluent.confluent-security-plugins.version>${confluent.version.range}</io.confluent.confluent-security-plugins.version>
+        <io.confluent.ksql.version>${confluent.version.range}</io.confluent.ksql.version>
     </properties>
 
     <dependencies>
@@ -52,31 +55,31 @@
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>cp-ksqldb-cli</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql-images.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>monitoring-interceptors</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.blueway.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-rest-app</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
         </dependency>
 
-	<dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-functional-tests</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-console-scripts</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>
@@ -85,7 +88,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-etc</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.ksql.version}</version>
             <classifier>resources</classifier>
             <type>zip</type>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>KSQL Docker Images</name>
     <description>Build files for Confluent's KSQL Docker images</description>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0-0</version>
 
     <modules>
         <module>cp-ksqldb-cli</module>
@@ -25,5 +25,6 @@
     
     <properties>
         <component.name>ksqldb</component.name>
+        <io.confluent.ksql-images.version>6.1.0-0</io.confluent.ksql-images.version>
     </properties>
 </project>


### PR DESCRIPTION
Setting the jenkins config to use nano versioning. Removed all of the snapshot versions and replaced with nano versions. Updated all of the dependency versions.
I had to adjust the docker image files as well because the wild card that is used to copy the ksql artifacts to the image did not work for the nano versioned artifacts.

These changes will be merged during phase two of the nano versioning roll out.