### PR TITLE
Add ksqldb-tools to pom files

### DIFF
--- a/cp-ksqldb-cli/pom.xml
+++ b/cp-ksqldb-cli/pom.xml
@@ -153,6 +153,12 @@
         </dependency>
 
         <dependency>
+          <groupId>io.confluent.ksql</groupId>
+          <artifactId>ksqldb-tools</artifactId>
+          <version>${io.confluent.ksql.version}</version>
+        </dependency>
+
+        <dependency>
           <groupId>org.hamcrest</groupId>
           <artifactId>hamcrest-all</artifactId>
           <version>1.3</version>

--- a/cp-ksqldb-server/pom.xml
+++ b/cp-ksqldb-server/pom.xml
@@ -77,6 +77,12 @@
         </dependency>
 
         <dependency>
+          <groupId>io.confluent.ksql</groupId>
+          <artifactId>ksqldb-tools</artifactId>
+          <version>${io.confluent.ksql.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksqldb-console-scripts</artifactId>
             <version>${io.confluent.ksql.version}</version>


### PR DESCRIPTION
Adding so that the migrations tool would be included in the packages.

Fixes #60