### PR TITLE
build: SR requires KAFKASTORE_BOOTSTRAP_SERVERS settings

### DIFF
--- a/cp-ksqldb-server/test/fixtures/basic-cluster.yml
+++ b/cp-ksqldb-server/test/fixtures/basic-cluster.yml
@@ -42,6 +42,7 @@ services:
     environment:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: PLAINTEXT://kafka:39092
     labels:
       - io.confluent.docker.testing=true
 


### PR DESCRIPTION
- SR now requires KAFKASTORE_BOOTSTRAP_SERVERS to boot

The 7.0.x and master jobs are failing:

```
==================================== ERRORS ====================================
15:47:04  ______________ ERROR at setup of KsqlServerTest.test_server_start ______________
15:47:04  [gw0] linux -- Python 3.6.12 /var/tmp/confluent/bin/python
15:47:04  
15:47:04  cls = <class 'test_ksql_server.KsqlServerTest'>
15:47:04  
15:47:04      @classmethod
15:47:04      def setup_class(cls):
15:47:04          cls.cluster = utils.TestCluster(
15:47:04              "ksql-server-test", FIXTURES_DIR, "basic-cluster.yml")
15:47:04          cls.cluster.start()
15:47:04          try:
15:47:04              start = time.time()
15:47:04              while time.time() - start < 30:
15:47:04  >               if check_cluster_ready(cls.cluster):
15:47:04  
15:47:04  test/test_ksql_server.py:81: 
15:47:04  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
15:47:04  test/test_ksql_server.py:25: in check_cluster_ready
15:47:04      for args in checks])
15:47:04  test/test_ksql_server.py:25: in <listcomp>
15:47:04      for args in checks])
15:47:04  /var/tmp/confluent/lib/python3.6/site-packages/confluent/docker_utils/__init__.py:182: in run_command_on_service
15:47:04      return self.run_command(command, self.get_container(service_name))
15:47:04  /var/tmp/confluent/lib/python3.6/site-packages/confluent/docker_utils/__init__.py:170: in get_container
15:47:04      return self.get_project().get_service(service_name).get_container()
15:47:04  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
15:47:04  
15:47:04  self = <Service: schema-registry>, number = 1
15:47:04  
15:47:04      def get_container(self, number=1):
15:47:04          """Return a :class:`compose.container.Container` for this service. The
15:47:04          container must be active, and match `number`.
15:47:04          """
15:47:04          for container in self.containers(labels=['{0}={1}'.format(LABEL_CONTAINER_NUMBER, number)]):
15:47:04              return container
15:47:04      
15:47:04  >       raise ValueError("No container found for %s_%s" % (self.name, number))
15:47:04  E       ValueError: No container found for schema-registry_1
```

This is because SR now requires the `kafkastore.boostrap.servers` settings in order to boot.