### PR TITLE
Add description label to ksqlDB server Dockerfile

### DIFF
--- a/cp-ksqldb-cli/pom.xml
+++ b/cp-ksqldb-cli/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>7.0.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/cp-ksqldb-cli/pom.xml
+++ b/cp-ksqldb-cli/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>7.0.0-0</version>
+        <version>7.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/cp-ksqldb-examples/pom.xml
+++ b/cp-ksqldb-examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>7.0.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/cp-ksqldb-examples/pom.xml
+++ b/cp-ksqldb-examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>7.0.0-0</version>
+        <version>7.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -18,6 +18,7 @@ LABEL version=$GIT_COMMIT
 LABEL release=$PROJECT_VERSION
 LABEL name=$ARTIFACT_ID
 LABEL summary="Confluent KSQL is the streaming SQL engine that enables real-time data processing against Apache Kafka®."
+LABEL description="Confluent KSQL is the streaming SQL engine that enables real-time data processing against Apache Kafka®."
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER

--- a/cp-ksqldb-server/pom.xml
+++ b/cp-ksqldb-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>6.2.0-0</version>
+        <version>7.0.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/cp-ksqldb-server/pom.xml
+++ b/cp-ksqldb-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-images-parent</artifactId>
-        <version>7.0.0-0</version>
+        <version>7.1.0-0</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[7.0.0-0, 7.0.1-0)</version>
+        <version>[7.1.0-0, 7.1.1-0)</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>KSQL Docker Images</name>
     <description>Build files for Confluent's KSQL Docker images</description>
-    <version>7.0.0-0</version>
+    <version>7.1.0-0</version>
 
     <modules>
         <module>cp-ksqldb-cli</module>
@@ -25,6 +25,6 @@
     
     <properties>
         <component.name>ksqldb</component.name>
-        <io.confluent.ksql-images.version>7.0.0-0</io.confluent.ksql-images.version>
+        <io.confluent.ksql-images.version>7.1.0-0</io.confluent.ksql-images.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[6.2.0-0, 6.2.1-0)</version>
+        <version>[7.0.0-0, 7.0.1-0)</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>KSQL Docker Images</name>
     <description>Build files for Confluent's KSQL Docker images</description>
-    <version>6.2.0-0</version>
+    <version>7.0.0-0</version>
 
     <modules>
         <module>cp-ksqldb-cli</module>
@@ -25,6 +25,6 @@
     
     <properties>
         <component.name>ksqldb</component.name>
-        <io.confluent.ksql-images.version>6.2.0-0</io.confluent.ksql-images.version>
+        <io.confluent.ksql-images.version>7.0.0-0</io.confluent.ksql-images.version>
     </properties>
 </project>


### PR DESCRIPTION
Some image scanning tools that check for vulnerabilities and OCI image best
practices expect to find a `description` label on images that is not inherited
from base images. The proposed change addresses this requirement.