### PR TITLE
Update Jenkinsfile Nodelabel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ dockerfile {
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
     mvnPhase = 'package integration-test'
     mvnSkipDeploy = true
-    nodeLabel = 'docker-oraclejdk8-compose'
+    nodeLabel = 'docker-debian-jdk8-compose'
     dockerPush = true
     slackChannel = '#ksql-eng'
 }


### PR DESCRIPTION
Update Jenkinsfile nodelabel to use new build image.

Context on new image: https://github.com/confluentinc/confluent-docker-build-images/pull/165/files

This will be pint merged up to master.