### PR TITLE
APPSEC-1156: Patch gson to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>commons-compress</artifactId>
             <version>1.21</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
     </dependencies>
     
     <properties>


### PR DESCRIPTION
Patch gson to be 2.9.0