### PR TITLE
feat: allow users to set custom log4j configs

### DIFF
--- a/cp-ksqldb-server/include/etc/confluent/docker/log4j.properties.template
+++ b/cp-ksqldb-server/include/etc/confluent/docker/log4j.properties.template
@@ -21,3 +21,9 @@ log4j.logger.processing=ERROR, kafka_appender
 log4j.logger.{{logger}}={{loglevel}}, stdout
 {% endfor %}
 {% endif %}
+
+# allow users to set whatever LOG4J configurations they want
+{% set kr_props = env_to_props('LOG4J_', '') -%}
+{% for name, value in kr_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}


### PR DESCRIPTION
Testing done:

`log4j.template`:
```
{% set kr_props = env_to_props('LOG4J_', '') -%}
{% for name, value in kr_props.items() -%}
{{name}}={{value}}
{% endfor -%}
```

Console:
```
% export LOG4J_LOG4J_FOO_BAR='baz'
% python3.9 -i confluent/docker_utils/dub.py
>>> fill_and_write_template('/Users/almog.gavra/dev/confluent/confluent-docker-utils/log4j.template', '/Users/almog.gavra/dev/confluent/confluent-docker-utils/log4j.properties')
True
% cat log4j.properties
log4j.foo.bar=baz
```