### PR TITLE
Adding Jq to ksql-cli image

### DIFF
--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -60,6 +60,8 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && mkdir -p /usr/share/confluent-hub-components \
     && chown appuser:appuser -R /usr/share/confluent-hub-components
+    
+RUN yum install -y jq
 
 USER appuser
 


### PR DESCRIPTION
As an User, I have a need to manipulate image tool's output such as ksql or ksql-test-runner.
For now, I've created a custom image : https://github.com/orange-cloudfoundry/orange-ksql-enriched
But I think it might be a great add to the base image.


# I need :

Some tool like jq to process JSON outputs.


# Suggested solution :

Include jq into ksql image.


# Observed behavior :

As a user of ksql and ksql-test-runner tool in order to manipulate data. I use jq to read output of ksql queries, and also to organize my test data.

JSON being a supported by ksql, the image should have some tooling available to properly read data in this format.