### PR TITLE
chore: manage netty versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,89 @@
         <module>cp-ksqldb-examples</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+        <!-- Explicitly override all netty artifacts to get the version we want. Doing netty-all
+        doesn't seem to correctly override its individual dependencies, so all are enumerated
+        here -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-socks</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty-codec-http2-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-tcnative-boringssl-static</artifactId>
+                <version>${netty-tcnative-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -37,6 +120,15 @@
     </dependencies>
     
     <properties>
+        <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
+        <!-- We normally get this from common, but Vertx is built against this -->
+        <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
+             we might need to bump `tcnative`, too.
+             Please check top level `pom.xml` at https://github.com/netty/netty
+             for the netty version we bump to (ie, corresponding git tag),
+             to find the correct `tcnative` version. -->
+        <netty.version>4.1.84.Final</netty.version>
+        <netty-codec-http2-version>4.1.84.Final</netty-codec-http2-version>
         <component.name>ksqldb</component.name>
     </properties>
 </project>


### PR DESCRIPTION
netty versions are up-managed in ksql-parent maven project, from the common maven project. However, the ksql-images-parent project does not get the overrides, because it does not derive from ksql-parent but from common-docker.

Without larger structural changes, we need to up-manage the versions in this maven project as well.