### PR TITLE
Update slack channel to ksqldb-warn

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ dockerfile {
     nodeLabel = 'docker-debian-jdk8-compose'
     usePackages = true
     dockerPush = true
-    slackChannel = '#ksqldb-quality-oncall'
+    slackChannel = '#ksqldb-warn'
     cron = ''
     usePackages = true
     cpImages = true


### PR DESCRIPTION
It's nice to have build failure alerts for master to go to #ksqldb-quality-oncall, but for old branches we should send the alerts to #ksqldb-warn in order to avoid spamming #ksqldb-quality-oncall. This used to be the case previously, which is why 7.0.x and earlier are already sending alerts to #ksqldb-warn. When new branches are cut, they need to be updated.