### PR TITLE
chore: Upgrade netty to 4.1.100.Final for CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,15 +120,15 @@
     </dependencies>
     
     <properties>
-        <netty-tcnative-version>2.0.54.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.86.Final</netty.version>
-        <netty-codec-http2-version>4.1.86.Final</netty-codec-http2-version>
+        <netty.version>4.1.100.Final</netty.version>
+        <netty-codec-http2-version>4.1.100.Final</netty-codec-http2-version>
         <component.name>ksqldb</component.name>
         <io.confluent.ksql-images.version>7.6.0-0</io.confluent.ksql-images.version>
     </properties>


### PR DESCRIPTION
This PR upgrades netty to 4.1.00.Final and netty-tcnative-version to 2.0.61.Final to address https://nvd.nist.gov/vuln/detail/CVE-2023-44487.

4.1.100.Final address the vulnerability according to https://netty.io/news/2023/10/10/4-1-100-Final.html.

also: https://github.com/confluentinc/ksql/pull/10080