### PR TITLE
chore: Upgrade netty to 4.1.100.Final to address CVE-2023-44487

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,15 +120,15 @@
     </dependencies>
     
     <properties>
-        <netty-tcnative-version>2.0.46.Final</netty-tcnative-version>
+        <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->
         <!-- Note: `netty` depends on `tcnative` and if we bump `netty`
              we might need to bump `tcnative`, too.
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.89.Final</netty.version>
-        <netty-codec-http2-version>4.1.89.Final</netty-codec-http2-version>
+        <netty.version>4.1.100.Final</netty.version>
+        <netty-codec-http2-version>4.1.100.Final</netty-codec-http2-version>
         <component.name>ksqldb</component.name>
         <io.confluent.ksql-images.version>6.1.14-0</io.confluent.ksql-images.version>
     </properties>


### PR DESCRIPTION
Backport of #105 for CP releases for CVE-2023-44487