### PR TITLE
chore: replace ADD with COPY in docker files

### DIFF
--- a/cp-ksqldb-cli/Dockerfile.ubi8
+++ b/cp-ksqldb-cli/Dockerfile.ubi8
@@ -27,10 +27,10 @@ ARG CONFLUENT_PLATFORM_LABEL
 
 USER root
 
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
-ADD --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+COPY --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 

--- a/cp-ksqldb-examples/Dockerfile.ubi8
+++ b/cp-ksqldb-examples/Dockerfile.ubi8
@@ -17,9 +17,9 @@ LABEL summary="Confluent KSQL is the streaming SQL engine that enables real-time
 
 USER root
 
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${KSQL_EXAMPLES_ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${KSQL_EXAMPLES_ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
-ADD --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${KSQL_EXAMPLES_ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${KSQL_EXAMPLES_ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+COPY --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
 
 USER appuser

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -30,10 +30,10 @@ ARG CONFLUENT_PLATFORM_LABEL
 
 USER root
 
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
-ADD --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+COPY --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/ksqldb/
 
 COPY --chown=appuser:appuser target/dependency/ksqldb-etc-*/* /etc/confluent/docker/
 COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docker/


### PR DESCRIPTION
As part of [FedRAMP M3](https://confluentinc.atlassian.net/browse/FEDRAMP-216) Container Hardening Requirements mentioned in this [doc](https://confluentinc.atlassian.net/wiki/spaces/~578374643/pages/3126199411/FedRAMP+Container+Hardening+Requirements), using [ADD](https://confluentinc.atlassian.net/wiki/spaces/~578374643/pages/3126199411/FedRAMP+Container+Hardening+Requirements#Ensure-that-COPY-is-used-instead-of-ADD-in-Dockerfiles-(Manual)) command is restricted in Dockerfiles.

This PR replaces ADD with COPY in docker files.

https://confluentinc.atlassian.net/browse/KSQL-11502