### PR TITLE
fix: attempt to disable writing test metadata

### DIFF
--- a/cp-ksqldb-examples/pom.xml
+++ b/cp-ksqldb-examples/pom.xml
@@ -135,7 +135,6 @@
                                 <KSQL_EXAMPLES_ARTIFACT_ID>ksqldb-examples</KSQL_EXAMPLES_ARTIFACT_ID>
                             </buildArgs>
                             <repository>${docker.registry}confluentinc/ksqldb-examples</repository>
-                            <writeTestMetadata>false</writeTestMetadata>
                         </configuration>
                     </execution>
                 </executions>

--- a/cp-ksqldb-examples/pom.xml
+++ b/cp-ksqldb-examples/pom.xml
@@ -135,6 +135,7 @@
                                 <KSQL_EXAMPLES_ARTIFACT_ID>ksqldb-examples</KSQL_EXAMPLES_ARTIFACT_ID>
                             </buildArgs>
                             <repository>${docker.registry}confluentinc/ksqldb-examples</repository>
+                            <writeTestMetadata>false</writeTestMetadata>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,21 @@
             <version>1.21</version>
         </dependency>
     </dependencies>
-    
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.spotify</groupId>
+                    <artifactId>dockerfile-maven-plugin</artifactId>
+                    <configuration>
+                        <writeTestMetadata>false</writeTestMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <properties>
         <netty-tcnative-version>2.0.61.Final</netty-tcnative-version>
         <!-- We normally get this from common, but Vertx is built against this -->


### PR DESCRIPTION
I could not test this change. The idea is to disable writing testMetadata to avoid the Jenkins job failing.