### PR TITLE
[hotfix] revert the version change to unblock the build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.21</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
- Previous [version change](https://github.com/confluentinc/ksql-images/commit/ef47898f59b9c60f1f7b6f1c85449bbc69608a63) of cause [build failure](https://jenkins.confluent.io/job/confluentinc/job/ksql-images/job/7.5.x/259/) 
- This PR reverts the version change to unblock the build