### PR TITLE
[hotfix] Revert the version change to fix the build failure of 7.3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.21</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
# What

- The build of 7.3.x is failed due to the [version change of org.apache.commons](https://github.com/confluentinc/ksql-images/commit/b55fc7554cc6ecaf44b8a109babfb05ff71b8ebe).
- This PR reverts the version change to fix the failure. 