### PR TITLE
Add Push Latest to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -21,3 +21,4 @@ semaphore:
   use_packages: true
   cp_images: true
   sign_images: true
+  push_latest: true


### PR DESCRIPTION
`push_latest: true` is needed to fix the below error as per this documentation: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3211693075/Jenkins+-+Semaphore+self+migration+guide#How-do-I-migrate-dockerfile%3F

```
>       raise cls(e, response=response, explanation=explanation)08:27
E       docker.errors.NotFound: 404 Client Error: Not Found ("manifest for 519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/confluentinc/cp-ksqldb-server:dev-6.2.x-95e22bb6-ubi8.amd64 not found: manifest unknown: Requested image not found")08:27
/var/tmp/confluent/lib/python3.7/site-packages/docker/errors.py:31: NotFound
```

After this PR is merged, cc-service-bot will need to be run in this repo and the resulting Semaphore config changes will need to be backported to the version branches