### PR TITLE
update commons compress in line with other ksql-images versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.26</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
Update Commons compress to address CVE / bring it in line with all the other [ksql-images](https://confluentinc.atlassian.net/browse/KSQL-images) versions