### PR TITLE
MINOR: Update confluent-docker-utils as python version was bumped up to 3.12

### DIFF
--- a/cp-ksqldb-server/requirements.txt
+++ b/cp-ksqldb-server/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.30
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.58


### PR DESCRIPTION
Update confluent-docker-utils as python version was bumped up to 3.12
Python version was bumped up from 3.7 because the semaphore job could not download the deps.