### PR TITLE
Update confluent docker utils to 0.0.32

### DIFF
--- a/cp-ksqldb-server/requirements.txt
+++ b/cp-ksqldb-server/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.58
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.32


### PR DESCRIPTION
* MINOR: Update confluent-docker-utils as python version was bumped up to 3.12

* MINOR: Update confluent-docker-utils to 0.0.32