### PR TITLE
KSQL-12385 | Fix the python version to 3.8 which is compatible with confluent-docker-utils v30

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -25,7 +25,7 @@ global_job_config:
     commands:
       - checkout
       - sem-version java 8
-      - sem-version python 3.12
+      - sem-version python 3.8
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,7 @@ global_job_config:
     commands:
       - checkout
       - sem-version java 8
-      - sem-version python 3.12
+      - sem-version python 3.8
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/cp-ksqldb-server/requirements.txt
+++ b/cp-ksqldb-server/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.58
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.30

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: ksql-images
 lang: python
-lang_version: 3.12
+lang_version: 3.8
 git:
   enable: true
 code_artifact:


### PR DESCRIPTION
This PR pins the python version to 3.8 which is compatible with the pip version >= 10 and confluent-docker-utils v30