### PR TITLE
[DO NOT MERGE] CPBR-1835: adding python based pacakge_dedupe file

### DIFF
--- a/cp-ksqldb-server/Dockerfile.poc
+++ b/cp-ksqldb-server/Dockerfile.poc
@@ -1,0 +1,123 @@
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG} as cp-base-new
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-lite:${DOCKER_UPSTREAM_TAG} as cp-base-lite
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal as ksqldb-server-ubi-minimal
+
+ARG CP_MAJOR_MINOR_VERSION="7.4"
+ARG CP_FULL_VERSION="7.4.5-1"
+ARG RPM_PACKAGES_DIR="/root/rpms"
+
+ENV COMPONENT=ksqldb-server
+ENV KSQL_CLASSPATH=/usr/share/java/${COMPONENT}/*
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+
+RUN microdnf --nodocs install yum \
+    && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
+    && yum --nodocs update -y \
+    && yum --nodocs install -y --setopt=install_weak_deps=False  \
+    wget \
+    python39 \
+    "zulu11-ca-jre-headless${ZULU_OPENJDK_VERSION}"
+
+RUN mkdir -p ${RPM_PACKAGES_DIR} \
+        && wget -O ${RPM_PACKAGES_DIR}/archive.key https://packages.confluent.io/rpm/${CP_MAJOR_MINOR_VERSION}/archive.key \
+        && wget -O ${RPM_PACKAGES_DIR}/confluent-common-${CP_FULL_VERSION}.noarch.rpm  https://packages.confluent.io/rpm/${CP_MAJOR_MINOR_VERSION}/confluent-common-${CP_FULL_VERSION}.noarch.rpm \
+        && wget -O ${RPM_PACKAGES_DIR}/confluent-security-${CP_FULL_VERSION}.noarch.rpm  https://packages.confluent.io/rpm/${CP_MAJOR_MINOR_VERSION}/confluent-security-${CP_FULL_VERSION}.noarch.rpm \
+        && wget -O ${RPM_PACKAGES_DIR}/confluent-hub-client-${CP_FULL_VERSION}.noarch.rpm  https://packages.confluent.io/rpm/${CP_MAJOR_MINOR_VERSION}/confluent-hub-client-${CP_FULL_VERSION}.noarch.rpm \
+        && wget -O ${RPM_PACKAGES_DIR}/confluent-telemetry-${CP_FULL_VERSION}.noarch.rpm  https://packages.confluent.io/rpm/${CP_MAJOR_MINOR_VERSION}/confluent-telemetry-${CP_FULL_VERSION}.noarch.rpm
+
+RUN rpm --import ${RPM_PACKAGES_DIR}/archive.key \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-common-${CP_FULL_VERSION}.noarch.rpm \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-security-${CP_FULL_VERSION}.noarch.rpm \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-hub-client-${CP_FULL_VERSION}.noarch.rpm \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-telemetry-${CP_FULL_VERSION}.noarch.rpm
+
+COPY --from=cp-base-new /usr/share/java/cp-base-new /usr/share/java/cp-base-new
+COPY --from=cp-base-lite /usr/bin/ub /usr/bin/ub
+
+COPY --chown=1001:1001 target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${COMPONENT}/
+
+COPY package_dedupe.py /root/package_dedupe.py
+
+RUN cd /usr/share/java \
+      && rm -rf confluent-security/schema* confluent-security/connect confluent-security/kafka-rest \
+      && python3 /root/package_dedupe.py
+
+RUN yum remove python39 wget -y \
+        && yum clean all \
+        && yum autoremove -y
+
+RUN microdnf clean all
+
+FROM registry.access.redhat.com/ubi8/ubi-micro as ksqldb-server-ubi-micro-intermediate
+
+ARG CP_MAJOR_MINOR_VERSION="7.4"
+ARG CP_FULL_VERSION="7.4.5-1"
+ARG RPM_PACKAGES_DIR="/root/rpms"
+
+USER root
+
+COPY --from=ksqldb-server-ubi-minimal /usr/lib/jvm /usr/lib/jvm
+COPY --from=ksqldb-server-ubi-minimal /usr/lib/rpm /usr/lib/rpm
+COPY --from=ksqldb-server-ubi-minimal /usr/bin/rpm* /usr/bin/
+# libz.so is required by java
+COPY --from=ksqldb-server-ubi-minimal /usr/lib64/libz.so.1* \
+                                /usr/lib64/librpm.so.8* \
+                                /usr/lib64/librpmio.so.8* \
+                                /usr/lib64/libdb-5.*.so \
+                                /usr/lib64/ libsqlite3.so.0* \
+                                /usr/lib64/
+
+# Optionally, you can copy other necessary files for rpm functionality
+COPY --from=ksqldb-server-ubi-minimal /etc/rpm /etc/rpm
+
+COPY --from=ksqldb-server-ubi-minimal ${RPM_PACKAGES_DIR}/* ${RPM_PACKAGES_DIR}/
+
+RUN rpm --import ${RPM_PACKAGES_DIR}/archive.key \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-common-${CP_FULL_VERSION}.noarch.rpm \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-security-${CP_FULL_VERSION}.noarch.rpm \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-hub-client-${CP_FULL_VERSION}.noarch.rpm \
+        && rpm --install ${RPM_PACKAGES_DIR}/confluent-telemetry-${CP_FULL_VERSION}.noarch.rpm
+
+RUN rm -rf /usr/bin/rpm* /usr/lib/rpm /usr/lib64/librpm.so.8* \
+        /usr/lib64/librpmio.so.8* \
+        /usr/lib64/libdb-5.*.so \
+        /usr/lib64/libsqlite3.so.0* \
+        ${RPM_PACKAGES_DIR}
+
+RUN rm -rf /usr/share/java/* /usr/lib64/python3*
+
+COPY --from=ksqldb-server-ubi-minimal /usr/share/java /usr/share/java
+
+RUN ln -s /usr/lib/jvm/java-11-zulu-openjdk/bin/java /usr/bin/java
+
+
+FROM registry.access.redhat.com/ubi8/ubi-micro as ksqldb-server-final
+
+ENV COMPONENT=ksqldb-server
+ENV KSQL_CLASSPATH=/usr/share/java/${COMPONENT}/*
+ENV PATH="${PATH}:/usr/lib/jvm/java-11-zulu-openjdk:/usr/bin"
+
+COPY --chown=1001:1001 target/dependency/ksqldb-console-scripts-*/* /usr/bin/
+COPY --chown=1001:1001 target/dependency/ksqldb-etc-*/* /etc/ksqldb/
+COPY --chown=1001:1001 target/dependency/ksqldb-etc-*/* /etc/confluent/docker/
+COPY --chown=1001:1001 include/etc/confluent/docker/* /etc/confluent/docker/
+
+RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets /usr/logs \
+  && chown 1001:root -R /etc/${COMPONENT} /usr/logs \
+  && chmod ug+w -R /etc/${COMPONENT} /usr/logs
+
+COPY --from=ksqldb-server-ubi-micro-intermediate / /
+
+USER 1001

--- a/cp-ksqldb-server/package_dedupe.py
+++ b/cp-ksqldb-server/package_dedupe.py
@@ -1,0 +1,50 @@
+#! /usr/bin/env python3
+"""
+Execute this script from inside a directory full of potentially duplicate
+files.  It will check the shasum of every file recursively, saving the path
+of the first copy in a dictionary, and symlinking subsequently found
+duplicates back to that first copy.
+"""
+
+from hashlib import sha1
+from os import walk
+from os.path import relpath
+from pathlib import Path
+from typing import Dict
+import logging
+
+def shasum(pathname: Path) -> str:
+    """Return the shasum for the contents of PATHNAME."""
+    sha1sum = sha1()
+    with pathname.open(mode='rb') as source:
+        block = source.read(2**16)
+        while len(block) != 0:
+            sha1sum.update(block)
+            block = source.read(2**16)
+    return sha1sum.hexdigest()
+
+
+
+def dedupe(path: Path):
+# Keep track of every "first copy" of all files with the same shasum.
+    sha2path: Dict[str, Path] = {}
+
+    for dirname, _, filenames in walk(path):
+        for filename in filenames:
+            path = Path(dirname) / filename
+            if path.is_symlink():
+                # Executing the script again must be harmless.
+                continue
+
+            sha = shasum(path)
+            if sha not in sha2path:
+                # Record this PATH as the "first copy" with the given SHA.
+                sha2path[sha] = path
+            else:
+                # Otherwise, replace this file with a symlink to the "first copy".
+                orig = sha2path[sha]
+                target = relpath(str(orig), str(path.parent))
+                path.unlink()
+                path.symlink_to(target)
+                logging.info(f'DEDUP: ln -sf {target} {str(path)}')
+

--- a/cp-ksqldb-server/pom.xml
+++ b/cp-ksqldb-server/pom.xml
@@ -31,6 +31,7 @@
     <name>KSQL Server Docker image</name>
 
     <properties>
+        <docker.file>Dockerfile.poc</docker.file>
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
         <io.confluent.blueway.version>${confluent.version.range}</io.confluent.blueway.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modules>
         <module>cp-ksqldb-cli</module>
         <module>cp-ksqldb-server</module>
-        <module>cp-ksqldb-examples</module>
+<!--        <module>cp-ksqldb-examples</module>-->
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR is created to try out different strategies to reduce the size of ksql docker image. This change needs to be done in CP 7.9.x but as currently no nightly packages are available for CP 7.9.x, this PR is raised on 7.8.x branch.

For testing with CFK, image that is present in ECR is required, hence semaphore builds for this PR are required for building a ksql image.