### PR TITLE
KSQL-12807 | Fix CVE for netty-common and bump it to version 4.1.115.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
              Please check top level `pom.xml` at https://github.com/netty/netty
              for the netty version we bump to (ie, corresponding git tag),
              to find the correct `tcnative` version. -->
-        <netty.version>4.1.108.Final</netty.version>
-        <netty-codec-http2-version>4.1.108.Final</netty-codec-http2-version>
+        <netty.version>4.1.115.Final</netty.version>
+        <netty-codec-http2-version>4.1.115.Final</netty-codec-http2-version>
         <component.name>ksqldb</component.name>
         <io.confluent.ksql-images.version>7.7.0</io.confluent.ksql-images.version>
     </properties>


### PR DESCRIPTION
KSQL-12807 | Fix CVE for netty-common and bump it to version 4.1.115.