### PR TITLE
Clear maven cache

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -338,6 +338,8 @@ blocks:
               if [[ ! $IS_RELEASE && ! $IS_PREVIEW ]]; then
                 #use semaphore default maven config to deploy jars to codeartifact
                 cp /tmp/temp_settings.xml ~/.m2/settings.xml
+                #clear maven repository cache coming from previous blocks
+                rm -rf ~/.m2/repository
                 mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/ -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests -Ddocker.skip-build=true -Ddocker.skip-test=true 
               fi
             # Create manifest


### PR DESCRIPTION
We have made the build environment for nightly and RC pipelines similar in #180. This change caused failures in last stage (deploy maven) which was fixed in #192 . Now since the maven configs point to codeartifact, the failures occurred as it is trying to fetch jars from codeartifact which is conflicting with the jars built in previous stages.
This PR fixes build [failures](https://semaphore.ci.confluent.io/jobs/558f8e67-c325-41fb-b346-abad94d7e664) on 7.1.x docker images by clearing the maven cache
The failures occurred due to `Artifact io.confluent:common-docker:pom:7.1.16-0 is present in the local repository, but cached from a remote repository ID that is unavailable in current build context`