### PR TITLE
move ci-update-version to use same configs as mvn deploy command below it

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -332,14 +332,14 @@ blocks:
         - name: Create Manifest and Maven Deploy
           commands:
             - export DOCKER_PROD_IMAGE_NAME=$DOCKER_PROD_REGISTRY${DOCKER_REPOS// / $DOCKER_PROD_REGISTRY}
-            - ci-tools ci-update-version
-            - ci-tools ci-push-tag
             - |-
               if [[ ! $IS_RELEASE && ! $IS_PREVIEW ]]; then
                 #use semaphore default maven config to deploy jars to codeartifact
                 cp /tmp/temp_settings.xml ~/.m2/settings.xml
                 #clear maven repository cache coming from previous blocks
                 rm -rf ~/.m2/repository
+                ci-tools ci-update-version
+                ci-tools ci-push-tag
                 mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker -DaltDeploymentRepository=confluent-codeartifact-internal::default::https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/ -DrepositoryId=confluent-codeartifact-internal deploy -DskipTests -Ddocker.skip-build=true -Ddocker.skip-test=true 
               fi
             # Create manifest


### PR DESCRIPTION
`ci-tools ci-update-version` command involves mvn commands to replace version ranges and pins dependencies to specific nanoversions
Build failures will occur if `ci-tools ci-update-version` is placed before removing mvn cache (#193 ) as both commands will use different maven configs ( ci-tools ci-update-version will use configs set in prologue while mvn deploy will use codeartifact configs to fetch jars)
This PR fixes the issue by moving both commands after clearing the ~/m2/repository  