### PR TITLE
KSQL-13103 | Fix the kafka-ready command and mention the cluster id for the KRaft cluster.

### DIFF
--- a/cp-ksqldb-server/test/fixtures/basic-cluster.yml
+++ b/cp-ksqldb-server/test/fixtures/basic-cluster.yml
@@ -18,6 +18,7 @@ services:
       KAFKA_LISTENERS: 'PLAINTEXT://kafka:39092,CONTROLLER://kafka:39093,PLAINTEXT_HOST://0.0.0.0:9092'
       KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      CLUSTER_ID: '9-fLubcIRYqQaWkrwEThnQ'
     labels:
       - io.confluent.docker.testing=true
 

--- a/cp-ksqldb-server/test/test_ksql_server.py
+++ b/cp-ksqldb-server/test/test_ksql_server.py
@@ -7,7 +7,7 @@ import confluent.docker_utils as utils
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.join(CURRENT_DIR, "fixtures")
 KAFKA_READY = (
-    "bash -c 'cub kafka-ready {brokers} 40 " +
+    "bash -c 'cub kafka-ready -b kafka:39092 {brokers} 40 " +
     "&& echo PASS || echo FAIL'")
 SR_READY = "bash -c 'cub sr-ready {host} {port} 20 && echo PASS || echo FAIL'"
 


### PR DESCRIPTION
Fix the kafka-ready command and mention the cluster id for the KRaft cluster.