### PR TITLE
KSQL-12617 | Remove unwanted jars from cp-ksqldb-server docker image

### DIFF
--- a/cp-ksqldb-examples/Dockerfile.ubi8
+++ b/cp-ksqldb-examples/Dockerfile.ubi8
@@ -55,6 +55,7 @@ RUN echo "===> Cleaning up ..."  \
     && mkdir -p /usr/share/confluent-hub-components \
     && chown appuser:appuser -R /usr/share/confluent-hub-components \
     && mkdir -p /var/lib/kafka-streams \
-    && chown appuser:appuser -R /var/lib/kafka-streams
+    && chown appuser:appuser -R /var/lib/kafka-streams \
+    && rm -rf /usr/share/java/confluent-security/schema-registry /usr/share/java/confluent-security/connect /usr/share/java/confluent-security/kafka-rest
 
 USER appuser

--- a/cp-ksqldb-server/Dockerfile.ubi8
+++ b/cp-ksqldb-server/Dockerfile.ubi8
@@ -64,7 +64,8 @@ RUN echo "===> Cleaning up ..."  \
     && mkdir -p /usr/share/confluent-hub-components \
     && chown appuser:appuser -R /usr/share/confluent-hub-components \
     && mkdir -p /var/lib/kafka-streams \
-    && chown appuser:appuser -R /var/lib/kafka-streams
+    && chown appuser:appuser -R /var/lib/kafka-streams \
+    && rm -rf /usr/share/java/confluent-security/schema-registry /usr/share/java/confluent-security/connect /usr/share/java/confluent-security/kafka-rest
 
 COPY --chown=appuser:appuser include/etc/confluent/docker/* /etc/confluent/docker/
 


### PR DESCRIPTION
Remove unwanted jars from cp-ksqldb-server docker image
This PR removes the `confluent-security` dependencies for schema registry, connect and kafka-rest and keeps only the one for ksql.