### PR TITLE
using cp-server image for running ksql docker tests

### DIFF
--- a/cp-ksqldb-server/test/fixtures/basic-cluster.yml
+++ b/cp-ksqldb-server/test/fixtures/basic-cluster.yml
@@ -4,7 +4,7 @@ version: '2'
 services:
   kafka:
     hostname: kafka
-    image: "${DOCKER_TEST_REGISTRY}confluentinc/cp-enterprise-kafka:${DOCKER_TEST_TAG}"
+    image: "${DOCKER_TEST_REGISTRY}confluentinc/cp-server:${DOCKER_TEST_TAG}"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1


### PR DESCRIPTION
As part of CP 8.0, cp-enterprise-kafka image is getting deprecated in favour of cp-server