### PR TITLE
[KSQL-13251] |  Fix log folder name for cli

### DIFF
--- a/cp-ksqldb-cli/include/etc/confluent/docker/log4j2.yaml.template
+++ b/cp-ksqldb-cli/include/etc/confluent/docker/log4j2.yaml.template
@@ -1,4 +1,8 @@
 Configuration:
+  Properties:
+    Property:
+      - name: ksql.log.dir
+        value: ${sys:ksql.log.dir}
   Appenders:
     TimestampLogFileAppender:
       type: io.confluent.ksql.util.TimestampLogFileAppender


### PR DESCRIPTION
Fix log folder name for cli image. log4j yaml expects dynamic properties to set explicitly