### PR TITLE
update template with latest envToProps

### DIFF
--- a/cp-ksqldb-server/include/etc/confluent/docker/connect.properties.template
+++ b/cp-ksqldb-server/include/etc/confluent/docker/connect.properties.template
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-{{- $kr_props := envToProps "KSQL_CONNECT_" "" nil -}}
+{{- $kr_props := envToProps "KSQL_CONNECT_" "" nil nil nil -}}
 {{ range $k, $v := $kr_props }}
 {{ $k }}={{ $v }}
 {{ end }}

--- a/cp-ksqldb-server/include/etc/confluent/docker/ksqldb-server.properties.template
+++ b/cp-ksqldb-server/include/etc/confluent/docker/ksqldb-server.properties.template
@@ -13,7 +13,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-{{- $kr_props := envToProps "KSQL_" "" nil -}}
+{{- $kr_props := envToProps "KSQL_" "" nil nil nil -}}
 {{ range $k, $v := $kr_props }}
 {{ $k }}={{ $v }}
 {{ end }}


### PR DESCRIPTION
envToProps now takes additional arguments to skip properties that have been already defined
This PR fixes the call to envToProps with the correct number of properties