### PR TITLE
CPBR-2644: fixing labels for refreshed ksql images (#232)

### DIFF
--- a/cp-ksqldb-server/Dockerfile.ubi9
+++ b/cp-ksqldb-server/Dockerfile.ubi9
@@ -66,6 +66,11 @@ FROM registry.access.redhat.com/ubi9-minimal:${UBI_MINIMAL_VERSION}
 
 EXPOSE 8088
 
+ARG BUILD_NUMBER=-1
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ARG GIT_COMMIT
+
 ENV COMPONENT=ksqldb-server
 ENV KSQL_CLASSPATH=/usr/share/java/${COMPONENT}/*
 
@@ -79,8 +84,7 @@ LABEL description="Confluent KSQL is the streaming SQL engine that enables real-
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker=true
-
-ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.git.repo="confluentinc/ksql-images"
 
 USER root
 


### PR DESCRIPTION
(cherry picked from commit 8edc1dea31b499603e6c66b57210b7f87eabfb99)

cherry picked changes from PR merged in 8.0.x branch - https://github.com/confluentinc/ksql-images/pull/232