### PR TITLE
Update code artifact package paths for versions below 8.1.x

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,6 +8,8 @@ code_artifact:
   package_paths:
     - maven-snapshots/maven/io.confluent.ksql/ksql-images-parent
     - maven-snapshots/maven/io.confluent.ksql/cp-ksqldb-server
+    - maven-snapshots/maven/io.confluent.ksql/cp-ksqldb-cli
+    - maven-snapshots/maven/io.confluent.ksql/cp-ksqldb-examples
 semaphore:
   enable: true
   pipeline_type: cp-dockerfile


### PR DESCRIPTION
packages apart from cp-ksqldb-server are failing to deploy/publish due to missing codeartifacts package path. This PR addresses this