### PR TITLE
Remove integration test as maven phase from service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -21,7 +21,7 @@ semaphore:
   ]
   community_docker_repos: []
   community_maven_modules: []
-  maven_phase: 'package integration-test'
+  maven_phase: 'package'
   maven_skip_deploy: true
   build_arm: true
   nano_version: true


### PR DESCRIPTION
This pull request makes a minor update to the Maven build phase in the `service.yml` configuration, changing it to only run the `package` phase instead of both `package` and `integration-test`. 

Reason to skip:
Given that these sanity tests don't add much value as the docker images are tested in CFK tests anyways, we can follow other components and remove these tests. 
Another reason to skip: https://confluentinc.atlassian.net/browse/CPBR-2658

