### PR TITLE
test: validate blanket COPY /microdir/ / passes Red Hat cert

### DIFF
--- a/cp-ksqldb-server/Dockerfile.ubi9
+++ b/cp-ksqldb-server/Dockerfile.ubi9
@@ -76,17 +76,7 @@ LABEL io.confluent.docker.git.repo="confluentinc/ksql-images"
 
 USER root
 
-# Copy only ksql binaries from /usr/bin to avoid overwriting base image files
-# Blindly copying /usr/bin leads to RedHat certification failures
-COPY --from=builder /microdir/usr/bin/*ksql* /usr/bin/
-
-COPY --from=builder /microdir/usr/share/java/ /usr/share/java/
-
-COPY --from=builder /microdir/usr/share/doc/ /usr/share/doc/
-
-# /etc - only Confluent-specific directories (not system configs)
-COPY --from=builder /microdir/etc/ksqldb /etc/ksqldb
-COPY --from=builder /microdir/etc/confluent-hub-client /etc/confluent-hub-client
+COPY --from=builder /microdir/ /
 
 COPY include/etc/confluent/docker/ /etc/confluent/docker/
 RUN chown -R ${APP_UID}:${APP_GID} /etc/confluent/docker


### PR DESCRIPTION
## Summary
- Replaces selective COPY from `/microdir` with blanket `COPY --from=builder /microdir/ /`
- Testing whether `dnf --installroot` creates a self-consistent RPM database that passes Red Hat certification's `HasModifiedFiles` check

## Context
Local testing with the Red Hat preflight certification tool confirmed:
- **With `--installroot` + blanket COPY:** `HasModifiedFiles` → PASS (`rpm -Va` shows 3 trivial lines)
- **Without `--installroot` (old `COPY / /`):** `HasModifiedFiles` → FAIL (1,912 modified files)

The fresh RPM DB created by `--installroot` matches the installed files, so `rpm -Va` finds no mismatches.

## Test plan
- [ ] CI builds the image successfully
- [ ] Run Red Hat certification against the built image
- [ ] Verify `HasModifiedFiles` passes

**This is a test PR — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)