### PR TITLE
KSQL-15367: stop exposing unauthenticated remote JMX from cp-ksqldb-server

### DIFF
--- a/cp-ksqldb-server/include/etc/confluent/docker/launch
+++ b/cp-ksqldb-server/include/etc/confluent/docker/launch
@@ -14,9 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# JMX settings
-if [ -z "$KSQL_JMX_OPTS" ]; then
-  KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
+# JMX settings.
+# Remote JMX without authentication is a code-execution primitive for any peer
+# that can reach the port, so this image does not enable it. Operators who need
+# remote JMX set KSQL_JMX_OPTS explicitly, with authentication and TLS. See:
+# https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html
+#
+# When the operator supplies nothing we must still export a loopback-only value
+# rather than leaving KSQL_JMX_OPTS empty: ksql-run-class falls back to its own
+# default, which binds every interface with no authentication, and then appends
+# JMX_PORT to it. Exporting here is what keeps the listener on loopback.
+#
+# The flag that confines the listener is com.sun.management.jmxremote.host.
+# com.sun.management.jmxremote.local.only does NOT restrict the remote
+# connector -- with local.only=true and a port set, the JDK still binds the
+# RMI registry to the wildcard address and accepts remote connections.
+KSQL_JMX_OPTS_FROM_OPERATOR="${KSQL_JMX_OPTS-}"
+if [ -z "$KSQL_JMX_OPTS_FROM_OPERATOR" ]; then
+  export KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 fi
 
 # Ensure that KSQL picks up the correct log4j properties file
@@ -32,10 +47,21 @@ fi
 # the default is to pick the first IP (or network).
 export KSQL_JMX_HOSTNAME=${KSQL_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
 
-# JMX port to use
-if [  $KSQL_JMX_PORT ]; then
+# JMX port to use. ksql-run-class appends the port to whichever KSQL_JMX_OPTS
+# ends up being used, so setting JMX_PORT is all that is needed here.
+if [ -n "${KSQL_JMX_PORT-}" ]; then
   export JMX_PORT=$KSQL_JMX_PORT
-export KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Djava.rmi.server.hostname=$KSQL_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+
+  if [ -z "$KSQL_JMX_OPTS_FROM_OPERATOR" ]; then
+    echo "===> WARNING: KSQL_JMX_PORT is set but KSQL_JMX_OPTS is not."
+    echo "===> WARNING: JMX will listen on loopback only and will NOT accept remote connections."
+    echo "===> WARNING: To enable remote JMX, set KSQL_JMX_OPTS explicitly with authentication and TLS. See:"
+    echo "===> WARNING: https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html"
+  elif [[ $KSQL_JMX_OPTS != *"java.rmi.server.hostname"* && -n "$KSQL_JMX_HOSTNAME" ]]; then
+    # The JMX client needs to reach java.rmi.server.hostname, which the operator
+    # is unlikely to know at image-build time, so supply it if they have not.
+    export KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Djava.rmi.server.hostname=$KSQL_JMX_HOSTNAME"
+  fi
 fi
 
 echo "===> Launching ${COMPONENT} ... "

--- a/cp-ksqldb-server/test/jmx/JmxProbe.java
+++ b/cp-ksqldb-server/test/jmx/JmxProbe.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+/**
+ * Attempts an unauthenticated remote JMX connection to host:port and reports
+ * whether the MBean server was reachable.
+ *
+ * <p>Run from a container other than the one under test, so that "reachable"
+ * means genuinely reachable across the network rather than over loopback.
+ */
+public class JmxProbe {
+  public static void main(String[] args) {
+    if (args.length != 1) {
+      System.out.println("usage: JmxProbe <host:port>");
+      System.exit(2);
+    }
+    String target = args[0];
+    String url = "service:jmx:rmi:///jndi/rmi://" + target + "/jmxrmi";
+    try {
+      JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(url), null);
+      MBeanServerConnection mbeans = connector.getMBeanServerConnection();
+      String vmName =
+          (String) mbeans.getAttribute(new ObjectName("java.lang:type=Runtime"), "Name");
+      System.out.println("JMX_RESULT=REACHABLE"
+          + " target=" + target
+          + " mbeanCount=" + mbeans.getMBeanCount()
+          + " remoteVm=" + vmName);
+      connector.close();
+    } catch (Exception e) {
+      System.out.println("JMX_RESULT=UNREACHABLE"
+          + " target=" + target
+          + " cause=" + e.getClass().getSimpleName()
+          + ": " + String.valueOf(e.getMessage()).replace('\n', ' '));
+    }
+  }
+}

--- a/cp-ksqldb-server/test/jmx/README.md
+++ b/cp-ksqldb-server/test/jmx/README.md
@@ -1,0 +1,63 @@
+# JMX exposure verification
+
+End-to-end proof that `cp-ksqldb-server` does not ship a remotely reachable,
+unauthenticated JMX listener.
+
+```bash
+./verify-jmx-exposure.sh
+```
+
+One command. It builds the image from this repo, stands up a real Kafka, starts
+real ksqlDB servers, and attempts a real unauthenticated JMX connection against
+each **from a separate container**. Exits non-zero if any assertion fails.
+
+Requires Docker with Compose v2. No internal Confluent access is needed — both
+the `cp-base-new` base image and the Confluent RPMs are public.
+
+## Why it is built this way
+
+Nothing is stubbed. Each assertion is made against something the JVM actually
+did:
+
+| Evidence | How it is obtained |
+| --- | --- |
+| Flags the JVM really received | `/proc/1/cmdline` inside the container |
+| Address the listener really bound | `/proc/net/tcp{,6}` inside the container |
+| Whether a remote client can really connect | `JmxProbe.java`, run from another container |
+
+The published, unpatched image is run first as a **control**. If the control
+does not reproduce the vulnerability, the run fails — otherwise a test that
+asserts "remote JMX is refused" would pass just as happily against a broken
+network or a container that never started.
+
+## Scenarios
+
+| # | Environment | Expected |
+| --- | --- | --- |
+| control | published image, `KSQL_JMX_PORT=1099` | remote JMX **reachable** (the bug) |
+| 1 | patched, `KSQL_JMX_PORT=1099` | loopback-only bind, remote **refused**, warning logged |
+| 2 | patched, `KSQL_JMX_PORT` + explicit `KSQL_JMX_OPTS` | remote **reachable**, warning suppressed |
+| 3 | patched, neither set | no listener on 1099 |
+
+Scenario 2 matters as much as scenario 1: hardening the default is only correct
+if operators who deliberately enable remote JMX are still able to.
+
+## A note on `com.sun.management.jmxremote.local.only`
+
+`local.only=true` does **not** restrict the remote connector. With a JMX port
+set, the JDK still binds the RMI registry to the wildcard address and accepts
+remote connections; this was measured on Zulu OpenJDK 11.0.31, the JRE in this
+image. The flag that actually confines the listener is
+`com.sun.management.jmxremote.host`, which is what `launch` sets.
+
+Anything relying on `local.only` for network confinement is not protected.
+
+## Versions
+
+Overridable by environment variable:
+
+| Variable | Default |
+| --- | --- |
+| `BASE_TAG` | `7.5.15` |
+| `CONFLUENT_VERSION` | `7.5.15-1` |
+| `PACKAGES_REPO` | `https://packages.confluent.io/rpm/7.5` |

--- a/cp-ksqldb-server/test/jmx/docker-compose.kafka.yml
+++ b/cp-ksqldb-server/test/jmx/docker-compose.kafka.yml
@@ -1,0 +1,32 @@
+---
+# Minimal Kafka the ksqlDB container can pass its kafka-ready preflight against.
+# Only exists so that a real ksqlDB JVM comes up and binds its JMX listener.
+services:
+  zookeeper:
+    hostname: zookeeper
+    container_name: jmxtest-zookeeper
+    image: confluentinc/cp-zookeeper:${TEST_TAG:-7.5.15}
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks: [jmxtest]
+
+  kafka:
+    hostname: kafka
+    container_name: jmxtest-kafka
+    image: confluentinc/cp-kafka:${TEST_TAG:-7.5.15}
+    depends_on: [zookeeper]
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:39092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100
+    networks: [jmxtest]
+
+networks:
+  jmxtest:
+    name: jmxtest

--- a/cp-ksqldb-server/test/jmx/verify-jmx-exposure.sh
+++ b/cp-ksqldb-server/test/jmx/verify-jmx-exposure.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# End-to-end proof that cp-ksqldb-server does not expose an unauthenticated
+# remote JMX listener.
+#
+#   ./verify-jmx-exposure.sh
+#
+# Builds the image from this repo, stands up a real Kafka, starts real ksqlDB
+# servers, and -- from a separate container -- attempts a real unauthenticated
+# JMX connection against each. Nothing is stubbed: the assertions are made
+# against the JVM's actual command line, its actual listening sockets, and an
+# actual remote MBean read.
+#
+# The published, unpatched image is run as a control so the test demonstrates
+# the vulnerability it is guarding against rather than just asserting the fix.
+#
+# Requires: docker (with compose v2). No internal Confluent access needed --
+# the base image and RPMs are both public.
+
+# Deliberately no pipefail: this script leans on `grep -q` and `head -1`, which
+# exit early and SIGPIPE their upstream, and under pipefail that reads as a
+# failed pipeline.
+set -u
+
+BASE_TAG="${BASE_TAG:-7.5.15}"                # cp-base-new / control-image tag
+CONFLUENT_VERSION="${CONFLUENT_VERSION:-7.5.15-1}"
+PACKAGES_REPO="${PACKAGES_REPO:-https://packages.confluent.io/rpm/7.5}"
+PATCHED_IMAGE="cp-ksqldb-server:jmx-verify"
+PROBE_IMAGE="cp-ksqldb-server:jmx-probe"
+CONTROL_IMAGE="confluentinc/cp-ksqldb-server:${BASE_TAG}"
+NETWORK=jmxtest
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPONENT_DIR="$(cd "$HERE/../.." && pwd)"
+
+PASS=0
+FAIL=0
+
+log()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+ok()   { printf '   \033[32mPASS\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad()  { printf '   \033[31mFAIL\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+info() { printf '        %s\n' "$*"; }
+
+cleanup() {
+  docker rm -f jmxtest-default jmxtest-optin jmxtest-noport jmxtest-control >/dev/null 2>&1
+  docker compose -f "$HERE/docker-compose.kafka.yml" down -v >/dev/null 2>&1
+  docker network rm "$NETWORK" >/dev/null 2>&1
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------- helpers ---
+
+# Print the JMX-related flags the JVM in $1 was actually started with.
+jvm_jmx_flags() {
+  docker exec "$1" bash -c 'tr "\0" "\n" < /proc/1/cmdline' 2>/dev/null \
+    | grep -i 'jmxremote\|rmi.server' | sort
+}
+
+# Print the bind address of the listening socket on port $2 inside container $1.
+# Hex, as the kernel reports it: 0100007F/0B00007F == 127.0.0.1,
+# ...FFFF00000100007F == ::ffff:127.0.0.1, all-zero == wildcard.
+listen_addr_for_port() {
+  docker exec "$1" bash -c '
+    want='"$2"'
+    for f in /proc/net/tcp /proc/net/tcp6; do
+      while read -r l; do
+        set -- $l; [ "$1" = "sl" ] && continue
+        p=$((16#${2##*:}))
+        if [ "$p" = "$want" ] && [ "$4" = "0A" ]; then echo "${2%%:*}"; fi
+      done < $f
+    done' 2>/dev/null | head -1
+}
+
+is_loopback_addr() {
+  case "$1" in
+    0100007F|0B00007F|*FFFF00000100007F) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Real unauthenticated JMX connect from a container that is not the target.
+remote_jmx_probe() {
+  docker run --rm --network "$NETWORK" "$PROBE_IMAGE" \
+    timeout 60 java -cp /probe JmxProbe "$1" \
+    2>/dev/null | grep '^JMX_RESULT=' | head -1
+}
+
+start_ksql() {
+  local name="$1" image="$2"; shift 2
+  docker rm -f "$name" >/dev/null 2>&1
+  docker run -d --name "$name" --network "$NETWORK" --hostname "$name" \
+    -e KSQL_BOOTSTRAP_SERVERS=kafka:39092 \
+    -e KSQL_LISTENERS=http://0.0.0.0:8088 \
+    "$@" "$image" >/dev/null
+  for _ in $(seq 1 100); do
+    docker logs "$name" 2>&1 | grep -q "Server up and running" && return 0
+    [ "$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null)" = "running" ] || break
+    sleep 3
+  done
+  echo "ksqlDB container $name never came up:" >&2
+  docker logs "$name" 2>&1 | tail -20 >&2
+  return 1
+}
+
+# ------------------------------------------------------------------ setup ---
+
+log "Building $PATCHED_IMAGE from $COMPONENT_DIR/Dockerfile.ubi8"
+docker build \
+  --build-arg DOCKER_UPSTREAM_REGISTRY= \
+  --build-arg DOCKER_UPSTREAM_TAG="$BASE_TAG" \
+  --build-arg CONFLUENT_VERSION="$CONFLUENT_VERSION" \
+  --build-arg CONFLUENT_PACKAGES_REPO="$PACKAGES_REPO" \
+  --build-arg PROJECT_VERSION="${BASE_TAG}-jmx-verify" \
+  --build-arg ARTIFACT_ID=cp-ksqldb-server \
+  --build-arg GIT_COMMIT="$(git -C "$COMPONENT_DIR" rev-parse --short HEAD 2>/dev/null || echo local)" \
+  -f "$COMPONENT_DIR/Dockerfile.ubi8" -t "$PATCHED_IMAGE" "$COMPONENT_DIR" >/dev/null 2>&1 || {
+    echo "build failed" >&2; exit 1; }
+info "built $PATCHED_IMAGE"
+
+# Compile the probe once, so each scenario's probe is a bare `java` run.
+if ! docker build -q -t "$PROBE_IMAGE" -f - "$HERE" >/dev/null 2>&1 <<EOF
+FROM $PATCHED_IMAGE
+USER root
+COPY JmxProbe.java /probe/
+RUN javac /probe/JmxProbe.java
+EOF
+then
+  echo "probe build failed" >&2
+  exit 1
+fi
+info "built $PROBE_IMAGE"
+
+log "Starting Kafka"
+docker compose -f "$HERE/docker-compose.kafka.yml" up -d >/dev/null 2>&1
+for _ in $(seq 1 60); do
+  docker exec jmxtest-kafka kafka-broker-api-versions \
+    --bootstrap-server kafka:39092 >/dev/null 2>&1 && break
+  sleep 2
+done
+info "kafka ready"
+
+# -------------------------------------------------------------- scenarios ---
+
+log "CONTROL: published unpatched $CONTROL_IMAGE with KSQL_JMX_PORT=1099"
+docker pull "$CONTROL_IMAGE" >/dev/null 2>&1
+if start_ksql jmxtest-control "$CONTROL_IMAGE" -e KSQL_JMX_PORT=1099; then
+  jvm_jmx_flags jmxtest-control | sed 's/^/        /'
+  addr=$(listen_addr_for_port jmxtest-control 1099)
+  info "port 1099 bound to: ${addr:-<none>}"
+  res=$(remote_jmx_probe jmxtest-control:1099)
+  info "$res"
+  case "$res" in
+    JMX_RESULT=REACHABLE*)
+      ok "control reproduces the vulnerability (remote unauthenticated JMX succeeds)" ;;
+    *)
+      bad "control did NOT reproduce the vulnerability -- the test proves nothing" ;;
+  esac
+fi
+
+log "SCENARIO 1: patched image, KSQL_JMX_PORT=1099, no KSQL_JMX_OPTS"
+if start_ksql jmxtest-default "$PATCHED_IMAGE" -e KSQL_JMX_PORT=1099; then
+  jvm_jmx_flags jmxtest-default | sed 's/^/        /'
+
+  if docker logs jmxtest-default 2>&1 | grep -q "WARNING: KSQL_JMX_PORT is set but KSQL_JMX_OPTS is not"; then
+    ok "operator warning is emitted"
+  else
+    bad "operator warning was not emitted"
+  fi
+
+  if docker logs jmxtest-default 2>&1 | grep -q "docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html"; then
+    ok "warning points at the monitoring docs"
+  else
+    bad "warning does not reference the monitoring docs"
+  fi
+
+  addr=$(listen_addr_for_port jmxtest-default 1099)
+  info "port 1099 bound to: ${addr:-<none>}"
+  if is_loopback_addr "$addr"; then
+    ok "JMX listener is bound to loopback"
+  else
+    bad "JMX listener is NOT bound to loopback (addr=${addr:-<none>})"
+  fi
+
+  res=$(remote_jmx_probe jmxtest-default:1099)
+  info "$res"
+  case "$res" in
+    JMX_RESULT=UNREACHABLE*) ok "remote JMX connection is refused" ;;
+    *)                       bad "remote JMX connection SUCCEEDED -- still exposed" ;;
+  esac
+
+  if docker exec jmxtest-default jcmd 1 VM.flags >/dev/null 2>&1; then
+    ok "local in-container JVM management still works"
+  else
+    bad "local in-container JVM management broke"
+  fi
+
+  if docker exec jmxtest-default bash -c 'timeout 5 bash -c "</dev/tcp/127.0.0.1/8088"' 2>/dev/null; then
+    ok "ksqlDB REST listener unaffected"
+  else
+    bad "ksqlDB REST listener is not up"
+  fi
+fi
+
+log "SCENARIO 2: patched image, operator supplies KSQL_JMX_OPTS (opt-in must still work)"
+if start_ksql jmxtest-optin "$PATCHED_IMAGE" \
+     -e KSQL_JMX_PORT=1099 \
+     -e KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.rmi.port=1099"; then
+  jvm_jmx_flags jmxtest-optin | sed 's/^/        /'
+
+  if docker logs jmxtest-optin 2>&1 | grep -q "WARNING: KSQL_JMX_PORT is set but KSQL_JMX_OPTS is not"; then
+    bad "warning was emitted even though the operator supplied KSQL_JMX_OPTS"
+  else
+    ok "warning correctly suppressed when operator opts in"
+  fi
+
+  if jvm_jmx_flags jmxtest-optin | grep -q 'java.rmi.server.hostname='; then
+    ok "java.rmi.server.hostname injected for the bridged-network case"
+  else
+    bad "java.rmi.server.hostname was not injected"
+  fi
+
+  if jvm_jmx_flags jmxtest-optin | grep -q 'jmxremote.host=127.0.0.1'; then
+    bad "loopback default leaked into operator-supplied opts"
+  else
+    ok "operator opts are not overridden with the loopback default"
+  fi
+
+  res=$(remote_jmx_probe jmxtest-optin:1099)
+  info "$res"
+  case "$res" in
+    JMX_RESULT=REACHABLE*) ok "opt-in remote JMX still works" ;;
+    *)                     bad "opt-in remote JMX broke" ;;
+  esac
+fi
+
+log "SCENARIO 3: patched image, neither KSQL_JMX_PORT nor KSQL_JMX_OPTS"
+if start_ksql jmxtest-noport "$PATCHED_IMAGE"; then
+  jvm_jmx_flags jmxtest-noport | sed 's/^/        /'
+  addr=$(listen_addr_for_port jmxtest-noport 1099)
+  if [ -z "$addr" ]; then
+    ok "no JMX listener on 1099 when no port is requested"
+  else
+    bad "unexpected listener on 1099 (addr=$addr)"
+  fi
+fi
+
+# ----------------------------------------------------------------- result ---
+
+printf '\n\033[1m== Result: %d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Problem

Setting `KSQL_JMX_PORT` on a `cp-ksqldb-server` container produced a **remotely reachable, unauthenticated JMX/RMI listener**.

Verified against the published `confluentinc/cp-ksqldb-server:7.5.15`: from a second container on the same network, an anonymous JMX client connected and read 251 MBeans out of the ksqlDB JVM. That is a code-execution primitive for any peer that can reach the port.

`include/etc/confluent/docker/launch` built `KSQL_JMX_OPTS` with `authenticate=false` and `ssl=false`, then exported it with `local.only=false` plus `rmi.port`/`port` whenever `KSQL_JMX_PORT` was set. `ksql-run-class` only applies its own default when `KSQL_JMX_OPTS` is empty, so the exported value won and the listener bound the wildcard address.

## Change

In `include/etc/confluent/docker/launch`:

- When the operator supplies no `KSQL_JMX_OPTS`, export a loopback-only value. It has to be *exported* rather than left empty — `ksql-run-class` would otherwise apply its own default, which also binds every interface with no auth.
- `KSQL_JMX_PORT` alone no longer forces a remote listener. It sets `JMX_PORT` and logs a warning pointing at the [monitoring docs](https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html).
- Keep injecting `java.rmi.server.hostname` (genuinely docker-specific), but only when the operator supplied `KSQL_JMX_OPTS`, didn't already set the hostname, and `hostname -i` resolved.
- Fix the unquoted `if [ $KSQL_JMX_PORT ]` test.

## ⚠️ `local.only` does not do what it looks like it does

`com.sun.management.jmxremote.local.only=true` does **not** restrict the remote connector. Measured on Zulu OpenJDK 11.0.31, the JRE in this image:

| Flags | Bind address of port 1099 |
| --- | --- |
| `jmxremote.port=1099` | `::` — all interfaces |
| `+ local.only=true` | `::` — **all interfaces** |
| `+ jmxremote.host=127.0.0.1` | `::ffff:127.0.0.1` — loopback |
| `+ java.rmi.server.hostname=127.0.0.1` | `::` — all interfaces |

An earlier revision of this PR used `local.only=true` and was caught by the e2e test below — it looked correct and changed nothing. The flag that actually confines the listener is `com.sun.management.jmxremote.host`.

**This matters beyond this PR:** anything relying on `local.only` for network confinement is not protected. The unmerged KSQL-13769 change to `bin/ksql-run-class` in `confluentinc/ksql` is currently written against `local.only` and should be revisited.

## Verification

```bash
./cp-ksqldb-server/test/jmx/verify-jmx-exposure.sh
```

One command, no internal Confluent access needed (base image and RPMs are both public). Result on this branch: **12 passed, 0 failed**.

Nothing is stubbed. Assertions are made against `/proc/1/cmdline` (flags the JVM really got), `/proc/net/tcp{,6}` (address it really bound), and a real remote MBean read from a separate container.

The published unpatched image runs first as a **control** — if it fails to reproduce the vulnerability, the suite fails, so "remote JMX refused" can't pass against a broken network or a container that never started.

| # | Environment | Expected | Result |
| --- | --- | --- | --- |
| control | published image, `KSQL_JMX_PORT=1099` | remote JMX reachable (the bug) | ✅ reproduced |
| 1 | patched, `KSQL_JMX_PORT=1099` | loopback bind, remote refused, warning | ✅ |
| 2 | patched, `KSQL_JMX_PORT` + explicit `KSQL_JMX_OPTS` | remote reachable, warning suppressed | ✅ |
| 3 | patched, neither set | no listener on 1099 | ✅ |

Scenario 2 matters as much as scenario 1: hardening the default is only correct if operators who deliberately enable remote JMX still can. Local in-container `jcmd` and the ksqlDB REST listener on 8088 are both asserted unaffected.

## ⚠️ Breaking change

Deployments that set `KSQL_JMX_PORT` to scrape JMX from outside the container will now bind loopback-only and must set `KSQL_JMX_OPTS` explicitly with authentication and TLS. **Needs a release note.**

## Scope

Targets `7.5.x` deliberately. Forward-merge to later branches will be handled through the normal ping-merge process — this is not proposed against `master`.

Related: KSQL-15367 (cc-spec-ksql template), KSQL-13769 (`bin/ksql-run-class`, unmerged), KSQL-13770 (healthchecks sidecar), K2-848 (kafka-broker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
