### PR TITLE
KSQL-15367: stop exposing unauthenticated remote JMX from cp-ksqldb-server

### DIFF
--- a/cp-ksqldb-server/include/etc/confluent/docker/launch
+++ b/cp-ksqldb-server/include/etc/confluent/docker/launch
@@ -14,9 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# JMX settings
-if [ -z "$KSQL_JMX_OPTS" ]; then
-  KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
+# JMX settings. Remote JMX without authentication allows remote code execution,
+# so it is off by default; set KSQL_JMX_OPTS to enable it. Must be exported --
+# ksql-run-class applies its own unrestricted default if KSQL_JMX_OPTS is empty.
+# jmxremote.host is what confines this listener, and java.rmi.server.hostname
+# must match it, or the registry hands clients a stub pointing at the container
+# IP and loopback connections are refused too. local.only is set for the
+# separate local connector; it is not read on this path, so do not treat it as
+# the thing keeping the port off the network.
+KSQL_JMX_OPTS_FROM_OPERATOR="${KSQL_JMX_OPTS-}"
+if [ -z "$KSQL_JMX_OPTS_FROM_OPERATOR" ]; then
+  export KSQL_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.host=127.0.0.1 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 fi
 
 # Ensure that KSQL picks up the correct log4j properties file
@@ -32,10 +40,19 @@ fi
 # the default is to pick the first IP (or network).
 export KSQL_JMX_HOSTNAME=${KSQL_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
 
-# JMX port to use
-if [  $KSQL_JMX_PORT ]; then
+# JMX port to use. ksql-run-class appends the port to whichever KSQL_JMX_OPTS is
+# in effect, so setting JMX_PORT is sufficient here.
+if [ -n "${KSQL_JMX_PORT-}" ]; then
   export JMX_PORT=$KSQL_JMX_PORT
-export KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Djava.rmi.server.hostname=$KSQL_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+
+  if [ -z "$KSQL_JMX_OPTS_FROM_OPERATOR" ]; then
+    echo "WARNING: KSQL_JMX_PORT is set without KSQL_JMX_OPTS. JMX will listen on loopback only."
+    echo "WARNING: To enable remote JMX, set KSQL_JMX_OPTS with authentication and TLS. See"
+    echo "WARNING: https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html"
+  elif [[ $KSQL_JMX_OPTS != *"java.rmi.server.hostname"* && -n "$KSQL_JMX_HOSTNAME" ]]; then
+    # Supply the RMI hostname the operator cannot know at image-build time.
+    export KSQL_JMX_OPTS="$KSQL_JMX_OPTS -Djava.rmi.server.hostname=$KSQL_JMX_HOSTNAME"
+  fi
 fi
 
 echo "===> Launching ${COMPONENT} ... "


### PR DESCRIPTION
## Problem

Setting `KSQL_JMX_PORT` on a `cp-ksqldb-server` container produced a **remotely reachable, unauthenticated JMX/RMI listener**.

Verified against the published `confluentinc/cp-ksqldb-server:7.5.15`: from a second container on the same network, an anonymous JMX client connected and read 251 MBeans out of the ksqlDB JVM. That is a code-execution primitive for any peer that can reach the port.

`include/etc/confluent/docker/launch` built `KSQL_JMX_OPTS` with `authenticate=false` and `ssl=false`, then exported it with `local.only=false` plus `rmi.port`/`port` whenever `KSQL_JMX_PORT` was set. `ksql-run-class` only applies its own default when `KSQL_JMX_OPTS` is empty, so the exported value won and the listener bound the wildcard address.

## Change

One file, `include/etc/confluent/docker/launch`:

- When the operator supplies no `KSQL_JMX_OPTS`, export a loopback-only value. It has to be *exported* rather than left empty — `ksql-run-class` would otherwise apply its own default, which also binds every interface with no auth.
- `KSQL_JMX_PORT` alone no longer forces a remote listener. It sets `JMX_PORT` and logs a warning pointing at the [monitoring docs](https://docs.confluent.io/platform/current/ksqldb/operate-and-deploy/monitoring.html).
- Keep injecting `java.rmi.server.hostname` (genuinely docker-specific), but only when the operator supplied `KSQL_JMX_OPTS`, didn't already set the hostname, and `hostname -i` resolved.
- Fix the unquoted `if [ $KSQL_JMX_PORT ]` test.

## ⚠️ `local.only` does not do what it looks like it does

`com.sun.management.jmxremote.local.only=true` does **not** restrict the remote connector. Measured on Zulu OpenJDK 11.0.31, the JRE in this image:

| Flags | Bind address of port 1099 |
| --- | --- |
| `jmxremote.port=1099` | `::` — all interfaces |
| `+ local.only=true` | `::` — **all interfaces** |
| `+ jmxremote.host=127.0.0.1` | `::ffff:127.0.0.1` — loopback |
| `+ java.rmi.server.hostname=127.0.0.1` | `::` — all interfaces |

An earlier revision of this fix used `local.only=true` and was caught in testing — it looked correct and changed nothing. The flag that actually confines the listener is `com.sun.management.jmxremote.host`.

**This matters beyond this PR:** anything relying on `local.only` for network confinement is not protected. The unmerged KSQL-13769 change to `bin/ksql-run-class` in `confluentinc/ksql` is currently written against `local.only` and should be revisited.

### And binding the registry to loopback isn't sufficient either

Found by live-testing the CI image for this branch. RMI hands the client a *stub* whose address comes from `java.rmi.server.hostname`; with that unset it defaults to the container IP, which nothing is listening on:

| Flags | Loopback JMX connect |
| --- | --- |
| `host=127.0.0.1` | **UNREACHABLE** — `Connection refused to host: 172.18.0.4` |
| `+ java.rmi.server.hostname=127.0.0.1` | REACHABLE |

Without the second flag JMX isn't confined to loopback, it's **unusable even from loopback** — secure, but broken for anyone setting `KSQL_JMX_PORT` to scrape locally. Both flags are set together.

This is worth calling out because scenarios 1–3 below all passed against the revision that had this bug. Only asserting that loopback JMX *works* exposed it; asserting that remote JMX fails is not enough.

### Why the literal `127.0.0.1` and not `localhost`

Both bind `::ffff:127.0.0.1` under default settings, but `localhost` depends on `/etc/hosts` and the JVM's address-preference order. Measured in this image, which maps `localhost` to both `127.0.0.1` and `::1`:

| Flags | Bind address |
| --- | --- |
| `host=localhost` | `::ffff:127.0.0.1` |
| `host=localhost` + `-Djava.net.preferIPv6Addresses=true` | `::1` — **IPv4 loopback clients refused** |
| `host=127.0.0.1` + `-Djava.net.preferIPv6Addresses=true` | `::ffff:127.0.0.1` |

The literal address is deterministic regardless of JVM options that may arrive via `KSQL_OPTS`.

## Verification

Verified end to end against a real Kafka and real ksqlDB servers — both a locally built image and the **CI-built image for this branch pulled from ECR** (`dev-7.5.x-02fab07a-ubi8.amd64`).

Nothing stubbed. Assertions are made against `/proc/1/cmdline` (flags the JVM really received), `/proc/net/tcp{,6}` (address it really bound), a real remote MBean read from a **separate container**, and a real loopback MBean read from **inside** the container. The published unpatched image runs first as a control, so a false pass from a broken network or a container that never started is ruled out.

| # | Environment | Expected | Result |
| --- | --- | --- | --- |
| control | published 7.5.15, `KSQL_JMX_PORT=1099` | remote JMX reachable (the bug) | ✅ reproduced, 252 MBeans read |
| 1 | patched, `KSQL_JMX_PORT=1099` | loopback bind, remote refused, **loopback usable**, warning | ✅ |
| 2 | patched, `KSQL_JMX_PORT` + explicit `KSQL_JMX_OPTS` | remote reachable, warning suppressed | ✅ |
| 3 | patched, neither set | no listener on 1099 | ✅ |

13 assertions, 0 failures.

Scenario 2 matters as much as scenario 1: hardening the default is only correct if operators who deliberately enable remote JMX still can. The loopback-usability assertion in scenario 1 matters for the same reason in the other direction — it's what distinguishes *confined* from *broken*. Local in-container `jcmd` and the ksqlDB REST listener on 8088 are both asserted unaffected.

The harness is kept local rather than committed, to avoid adding a Docker-dependent suite to the repo. Happy to share it if useful for review.

## ⚠️ Breaking change

Deployments that set `KSQL_JMX_PORT` to scrape JMX from outside the container will now bind loopback-only and must set `KSQL_JMX_OPTS` explicitly with authentication and TLS. **Needs a release note.**

## Scope

Targets `7.5.x` deliberately. Forward-merge to later branches will be handled through the normal ping-merge process — this is not proposed against `master`.

Related: KSQL-15367 (cc-spec-ksql template), KSQL-13769 (`bin/ksql-run-class`, unmerged), KSQL-13770 (healthchecks sidecar), K2-848 (kafka-broker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
